### PR TITLE
website: implement baseline to render links inside code blocks

### DIFF
--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -31,8 +31,6 @@ import Json from "@site/static/toc.json";
 
 test 1234
 
-hello
-
 ```proto-spc
 message Person {
   string name = 1;
@@ -60,6 +58,18 @@ message AddressBook {
   repeated Person people = 1;
 }
 ```
+
+</Definition>
+
+<Definition name="Person">
+
+<DefinitionHeader name="message">
+
+## Person
+
+</DefinitionHeader>
+
+This is person description
 
 </Definition>
 

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -31,7 +31,7 @@ import Json from "@site/static/toc.json";
 
 test 1234
 
-```proto-spc
+```protosaurus
 message Person {
   string name = 1;
   int32 id = 2;  // Unique ID number for this person.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,7 +4,7 @@
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
-const protoMessageRemarkPlugin = require("./plugins/proto-messages");
+const protoMessageRehypePlugin = require("./plugins/proto-messages");
 
 /** @type {import('@docusaurus/core').Config} */
 const config = {
@@ -28,7 +28,7 @@ const config = {
           // Please change this to your repo.
           editUrl:
             "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
-          rehypePlugins: [protoMessageRemarkPlugin],
+          rehypePlugins: [protoMessageRehypePlugin],
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),

--- a/website/plugins/file.md
+++ b/website/plugins/file.md
@@ -6,7 +6,7 @@ hello
 hello2
 ```
 
-```proto-spc
+```protosaurus
 message Person {
   string name = 1;
   int32 id = 2;  // Unique ID number for this person.

--- a/website/plugins/file.md
+++ b/website/plugins/file.md
@@ -1,5 +1,11 @@
 hello world [./test](test)
 
+```
+hello
+
+hello2
+```
+
 ```proto-spc
 message Person {
   string name = 1;

--- a/website/plugins/proto-messages/index.js
+++ b/website/plugins/proto-messages/index.js
@@ -72,7 +72,7 @@ module.exports = () => {
                   val = "​\n";
                 }
               }
-              console.log(val);
+
               // Not found.
               children.push({
                 type: "text",

--- a/website/plugins/proto-messages/index.js
+++ b/website/plugins/proto-messages/index.js
@@ -1,6 +1,9 @@
 // Copyright 2022 Protosaurus Authors
 // Licensed under the Apache License, Version 2.0 (the "License")
 
+// TODO(imballinst): convert to TypeScript.
+// If Docusaurus can't support TypeScript plugin files, then we need
+// to convert to JavaScript files first in the `prebuild` hook.
 const DICTIONARY = {
   Person: "#person",
 };
@@ -17,7 +20,7 @@ module.exports = () => {
         const code = pre.children[0];
         const codeArray = code.children[0].value.split("\n");
 
-        if (!code.properties?.className?.includes("language-proto-spc")) {
+        if (!code.properties?.className?.includes("language-protosaurus")) {
           continue;
         }
 

--- a/website/plugins/proto-messages/index.js
+++ b/website/plugins/proto-messages/index.js
@@ -20,6 +20,7 @@ module.exports = () => {
         const code = pre.children[0];
         const codeArray = code.children[0].value.split("\n");
 
+        // TODO(imballinst): specify a better language code.
         if (!code.properties?.className?.includes("language-protosaurus")) {
           continue;
         }

--- a/website/plugins/proto-messages/index.js
+++ b/website/plugins/proto-messages/index.js
@@ -1,7 +1,8 @@
-const visit = require("unist-util-visit");
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
 
 const DICTIONARY = {
-  Person: "https://google.com",
+  Person: "#person",
 };
 
 module.exports = () => {
@@ -10,15 +11,20 @@ module.exports = () => {
     // to get the directory containing the intermediary JSON.
     // console.log(process.env);
 
-    console.log(JSON.stringify(tree, null, 2));
-
     for (const child of tree.children) {
       if (child.tagName === "pre") {
         const pre = child;
-        const code = pre.children[0].children[0].value.split("\n");
+        const code = pre.children[0];
+        const codeArray = code.children[0].value.split("\n");
+
+        if (!code.properties?.className?.includes("language-proto-spc")) {
+          continue;
+        }
 
         const children = [];
-        for (const line of code) {
+        for (let i = 0, length = codeArray.length - 1; i < length; i++) {
+          const line = codeArray[i];
+
           for (const key in DICTIONARY) {
             const idx = line.indexOf(key);
 
@@ -47,51 +53,38 @@ module.exports = () => {
                 },
                 {
                   type: "text",
-                  value: secondSlice,
+                  value: `${secondSlice}\n`,
                 }
               );
             } else {
+              const isNotLast = i + 1 < length;
+              let val = `${line}`;
+
+              // Add newline if not the last line.
+              if (isNotLast) {
+                val += "\n";
+
+                // In case of double space, we need to
+                // add another (as a result of .split()).
+                // We need to add this "zero-width space" otherwise
+                // the MDX renderer will remove the second newline.
+                if (line === "") {
+                  val = "​\n";
+                }
+              }
+              console.log(val);
               // Not found.
               children.push({
                 type: "text",
-                value: line,
+                value: val,
               });
             }
           }
         }
-        console.log(JSON.stringify(children, null, 2));
-        pre.children[0].children = children;
+
+        pre.children = children;
+        pre.tagName = "precustom";
       }
     }
-    // visit(tree, "pre", (node) => {
-    //   console.log(node);
-    //   // if (node.type === "code" && node.lang === "proto-spc") {
-    //   //   // Original node value:
-    //   //   // {
-    //   //   //   type: 'code',
-    //   //   //   lang: 'proto-spc',
-    //   //   //   meta: null,
-    //   //   //   value: 'message CheckResponse {\n' +
-    //   //   //     '\t// Status `OK` allows the request. Any other status indicates the request should be denied.\n' +
-    //   //   //     '\tgoogle.rpc.Status status = 1;\n' +
-    //   //   //     '\toneof http_response {\n' +
-    //   //   //     '\t\t// Supplies http attributes for a denied response.\n' +
-    //   //   //     '\t\tDeniedHttpResponse denied_response = 2;\n' +
-    //   //   //     '\t\t// Supplies http attributes for an ok response.\n' +
-    //   //   //     '\t\tOkHttpResponse ok_response = 3;\n' +
-    //   //   //     '\t}\n' +
-    //   //   //     '}',
-    //   //   //   position: [Position]
-    //   //   // }
-    //   //   const array = node.value.split("\n");
-
-    //   //   node.type = "html";
-    //   //   node.value = array
-    //   //     .map((line) => {
-    //   //       return `<p>${line}</p>`;
-    //   //     })
-    //   //     .join("");
-    //   // }
-    // });
   };
 };

--- a/website/plugins/test.js
+++ b/website/plugins/test.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 const mdx = require("@mdx-js/mdx");
 const fs = require("fs");
 const remarkProtoMessagePlugin = require("./proto-messages");

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -14,6 +14,14 @@
   --ifm-color-primary-lighter: rgb(102, 212, 189);
   --ifm-color-primary-lightest: rgb(146, 224, 208);
   --ifm-code-font-size: 95%;
+
+  --ifm-pre-color: rgb(57, 58, 52);
+  --ifm-pre-background-color: rgb(246, 248, 250);
+}
+
+html[data-theme="dark"] {
+  --ifm-pre-color: rgb(248, 248, 242);
+  --ifm-pre-background: rgb(40, 42, 54);
 }
 
 .docusaurus-highlight-code-line {
@@ -23,6 +31,16 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
-html[data-theme='dark'] .docusaurus-highlight-code-line {
+html[data-theme="dark"] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
+}
+
+precustom {
+  font: var(--ifm-code-font-size) / var(--ifm-pre-line-height)
+    var(--ifm-font-family-monospace);
+  white-space: pre;
+  background: var(--ifm-pre-background);
+  display: block;
+  padding: var(--ifm-pre-padding);
+  border-radius: var(--ifm-code-border-radius);
 }

--- a/website/src/theme/Definition.js
+++ b/website/src/theme/Definition.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 import React from "react";
 import styles from "./Definition.module.css";
 

--- a/website/src/theme/Definition.module.css
+++ b/website/src/theme/Definition.module.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 Protosaurus Authors
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
 /* Messages. */
 .definition {
   margin-bottom: var(--ifm-paragraph-margin-bottom);

--- a/website/src/theme/DefinitionHeader.js
+++ b/website/src/theme/DefinitionHeader.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 import React from "react";
 import styles from "./Definition.module.css";
 

--- a/website/src/theme/Description.js
+++ b/website/src/theme/Description.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 import React from "react";
 import styles from "./Description.module.css";
 

--- a/website/src/theme/Description.module.css
+++ b/website/src/theme/Description.module.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 Protosaurus Authors
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
 .description {
   border: 1px solid var(--ifm-toc-border-color);
   border-radius: 4px;

--- a/website/src/theme/ReferenceWrapper.js
+++ b/website/src/theme/ReferenceWrapper.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 import React from "react";
 import styles from "./ReferenceWrapper.module.css";
 

--- a/website/src/theme/ReferenceWrapper.module.css
+++ b/website/src/theme/ReferenceWrapper.module.css
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 Protosaurus Authors
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
 .wrapper h2 {
   border-bottom: 1px solid var(--ifm-toc-border-color);
   padding-bottom: 1rem;

--- a/website/src/theme/RpcDefinition.js
+++ b/website/src/theme/RpcDefinition.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 import React from "react";
 import styles from "./Definition.module.css";
 

--- a/website/src/theme/RpcDefinitionDescription.js
+++ b/website/src/theme/RpcDefinitionDescription.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 import React from "react";
 import styles from "./Definition.module.css";
 

--- a/website/src/theme/RpcDefinitionHeader.js
+++ b/website/src/theme/RpcDefinitionHeader.js
@@ -1,3 +1,6 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 import React from "react";
 import styles from "./Definition.module.css";
 


### PR DESCRIPTION
This PR implements baseline to render links inside code blocks (and perhaps many more in the future). Also adds missing copyright declarations in the previous files.

How it works:

1. It is explained in https://github.com/mdx-js/mdx/blob/v1/docs/advanced/plugins.mdx that there are some processes to transform a MDX to MDXAST, then to HAST. We are processing the HAST here.
2. We use a special code language here, `protosaurus`. We intercept this in the rehype plugin that we create, then process them inside. We will have a "dictionary" as well containing the type name and the link to it.
3. We use a bit of hack of zero-width space so that the MDX renderer is tricked into rendering few characters (instead of double newlines only). This is because, without the zero-width space, MDX renderer will strip the second newline.
4. We match the rendered custom code block with the one rendered by Docusaurus, the color, background, etc.

The demo can be found below.

https://user-images.githubusercontent.com/7077157/151104794-705f4854-7c62-43ff-b7fc-df6b81bdf61a.mov

Signed-off-by: Try Ajitiono <ballinst@gmail.com>