### PR TITLE
Implement package description component and sidebar custom label

### DIFF
--- a/mdx/emit.ts
+++ b/mdx/emit.ts
@@ -104,7 +104,8 @@ const CATEGORY_LABELS = {
     })
   );
 
-  // Create the metadatas.
+  // Create the metadata file.
+  // Add more to this array as needed later.
   promises.push([
     emitCategoryMetadata(PATH_TO_WKT_MDX_FOLDER, CATEGORY_LABELS.wkt),
   ]);

--- a/mdx/emit.ts
+++ b/mdx/emit.ts
@@ -22,7 +22,6 @@ const PATH_TO_PLUGIN_DICTIONARY_FOLDER = path.join(
   process.env.PWD!,
   "../website/plugins/proto-messages/dictionary"
 );
-
 const PATH_TO_WKT_MDX_FOLDER = `${PATH_TO_MDX_FOLDER}/wkt`;
 
 const PRESERVED_DOCS_FILES = ["intro.mdx"];

--- a/mdx/emit.ts
+++ b/mdx/emit.ts
@@ -1,4 +1,4 @@
-import { readdir } from "fs-extra";
+import { readdir, rm, stat } from "fs-extra";
 import path from "path";
 import {
   convertPackageToMdx,
@@ -17,12 +17,22 @@ const PATH_TO_GENERATED_WKT = path.join(
   "../website/generated/wkt"
 );
 const PATH_TO_MDX_FOLDER = path.join(process.env.PWD!, "../website/docs");
-const PATH_TO_PLUGIN_FOLDER = path.join(
+const PATH_TO_PLUGIN_DICTIONARY_FOLDER = path.join(
   process.env.PWD!,
   "../website/plugins/proto-messages/dictionary"
 );
 
+const PRESERVED_DOCS_FILES = ["intro.mdx"];
+
 (async () => {
+  // This does 2 things:
+  // 1. Delete all files except intro.mdx in `PATH_TO_MDX_FOLDER`.
+  // 2. Delete the dictionary folder `PATH_TO_PLUGIN_DICTIONARY_FOLDER`.
+  await Promise.all([
+    deleteDirectoryEntries(PATH_TO_MDX_FOLDER, PRESERVED_DOCS_FILES),
+    deleteDirectoryEntries(PATH_TO_PLUGIN_DICTIONARY_FOLDER),
+  ]);
+
   // Generate MDX and dictionary for local types.
   const localPackages = await recursivelyReadDirectory({
     pathToDirectory: PATH_TO_GENERATED,
@@ -32,9 +42,9 @@ const PATH_TO_PLUGIN_FOLDER = path.join(
 
   for (const pkg of localPackages) {
     const pathToMdx = `${PATH_TO_MDX_FOLDER}/${pkg.name}`;
-    const pathToPlugin = `${PATH_TO_PLUGIN_FOLDER}/${pkg.name}`;
+    const pathToPlugin = `${PATH_TO_PLUGIN_DICTIONARY_FOLDER}/${pkg.name}`;
 
-    promises.push(emitMdx(pathToMdx, pkg.messagesData));
+    promises.push(emitMdx(pathToMdx, pkg));
     promises.push(
       emitMessagesJson({
         filePath: pathToPlugin,
@@ -44,35 +54,21 @@ const PATH_TO_PLUGIN_FOLDER = path.join(
   }
 
   // Generate MDX and dictionary for well known types (WKT).
-  const packages = await recursivelyReadDirectory({
+  const wktPackages = await recursivelyReadDirectory({
     pathToDirectory: PATH_TO_GENERATED_WKT,
   });
-  const allWktMessageData: {
-    [index: string]: MessageData[];
-  } = {};
-
-  for (const pkg of packages) {
-    if (allWktMessageData[pkg.name] === undefined) {
-      allWktMessageData[pkg.name] = [];
-    }
-
-    allWktMessageData[pkg.name].push(...pkg.messagesData);
-  }
-
-  // Render MDX one-by-one.
-  // While doing so, we also merge all well known types in an array.
   const allWktMessages: MessageData[] = [];
 
-  for (const key in allWktMessageData) {
+  for (const pkg of wktPackages) {
     // We want to merge all WKTs in one file so it's not scattered.
-    const pathToMdx = `${PATH_TO_MDX_FOLDER}/wkt/${key}`;
+    const pathToMdx = `${PATH_TO_MDX_FOLDER}/wkt/${[pkg.name]}`;
 
-    allWktMessages.push(...allWktMessageData[key]);
-    promises.push(emitMdx(pathToMdx, allWktMessageData[key]));
+    allWktMessages.push(...pkg.messagesData);
+    promises.push(emitMdx(pathToMdx, pkg));
   }
 
   // Render all WKT JSON in one file.
-  const pathToWktFile = `${PATH_TO_PLUGIN_FOLDER}/wkt`;
+  const pathToWktFile = `${PATH_TO_PLUGIN_DICTIONARY_FOLDER}/wkt`;
   promises.push(
     emitMessagesJson({
       filePath: pathToWktFile,
@@ -84,6 +80,7 @@ const PATH_TO_PLUGIN_FOLDER = path.join(
   await Promise.all(promises);
 })();
 
+// Helper functions.
 async function recursivelyReadDirectory({
   pathToDirectory,
   excludedDirectories,
@@ -110,20 +107,48 @@ async function recursivelyReadDirectory({
 
     // If file, read its contents.
     if (entry.isFile()) {
-      const packageMessages = await convertPackageToMdx(pathToEntry);
-      const packageName = pathToEntry.slice(PATH_TO_GENERATED.length);
+      const packages = await convertPackageToMdx(pathToEntry);
 
-      allPackages.push(...packageMessages);
+      allPackages.push(...packages);
       continue;
     }
 
     // Otherwise, keep reading recursively.
-    const packageMessages = await recursivelyReadDirectory({
+    const packages = await recursivelyReadDirectory({
       pathToDirectory: pathToEntry,
       excludedDirectories,
     });
-    allPackages.push(...packageMessages);
+    allPackages.push(...packages);
   }
 
   return allPackages;
+}
+
+async function deleteDirectoryEntries(dir: string, exception?: string[]) {
+  try {
+    // Check for directory existence.
+    // If it doesn't exist, this will throw an error.
+    await stat(dir);
+
+    // If directory exists, proceed.
+    const entries = await readdir(dir, {
+      encoding: "utf-8",
+      withFileTypes: true,
+    });
+
+    // Delete without exception.
+    if (exception === undefined) {
+      return entries.map((entry) =>
+        rm(`${dir}/${entry.name}`, { recursive: true })
+      );
+    }
+
+    // Delete with exceptions.
+    const deletedEntries = entries.filter(
+      (entry) => !exception.includes(entry.name)
+    );
+    return deletedEntries.map((entry) =>
+      rm(`${dir}/${entry.name}`, { recursive: true })
+    );
+  } catch (err) {}
 }

--- a/mdx/lib/doc-to-mdx.ts
+++ b/mdx/lib/doc-to-mdx.ts
@@ -142,9 +142,6 @@ export async function emitMessagesJson({
     map[name] = `/docs/${isWkt ? "wkt/" : ""}${packageName}#${hash}`;
   }
 
-  // Check for existence and create parent directories, if not exist.
-  await createDirectoryIfNotExist(filePath);
-
   return writeFile(`${filePath}.json`, JSON.stringify(map));
 }
 

--- a/mdx/lib/doc-to-mdx.ts
+++ b/mdx/lib/doc-to-mdx.ts
@@ -143,7 +143,7 @@ export async function emitMessagesJson({
   }
 
   // Check for existence and create parent directories, if not exist.
-  await createParentDirectoriesIfNotExist(filePath);
+  await createDirectoryIfNotExist(filePath);
 
   return writeFile(`${filePath}.json`, JSON.stringify(map));
 }
@@ -153,9 +153,6 @@ export async function emitMdx(filePath: string, pkg: PackageData) {
   const messageStrings = pkg.messagesData
     .map((m) => m.messageStrings)
     .join("\n\n");
-
-  // Check for existence and create parent directories, if not exist.
-  await createParentDirectoriesIfNotExist(filePath);
 
   return writeFile(
     `${filePath}.mdx`,
@@ -177,17 +174,24 @@ ${messageStrings}\n`.trimStart()
   );
 }
 
-// Helper functions.
-async function createParentDirectoriesIfNotExist(filePath: string) {
-  const parentDirectory = path.dirname(filePath);
+export async function emitCategoryMetadata(directory: string, label: string) {
+  const metadata = `
+label: ${label}
+  `.trim();
 
+  return writeFile(`${directory}/_category_.yml`, metadata);
+}
+
+export async function createDirectoryIfNotExist(directory: string) {
   try {
-    await fs.stat(parentDirectory);
+    await fs.stat(directory);
   } catch (err) {
     // Not found.
-    await fs.mkdirp(parentDirectory);
+    await fs.mkdirp(directory);
   }
 }
+
+// Helper functions.
 
 function getPackageDescription(pkg: PackageData) {
   if (pkg.description === "") {


### PR DESCRIPTION
This PR implements the package description component `Description` in the generated MDX. Although at the moment there is no `description` in `package.description` (it's an empty string), it should be ready if one day we want to add package descriptions.

This PR also implements sidebar custom label. This is done by adding `_category_.yml` in the `docs/wkt` folder with the content as the following:

```yml
label: Well Known Types
```
## Open Items

I'm not sure whether to also group the `booking.v1` and `location.v1` to say, "Packages" category or something.

## Misc.

This PR also adjusts the folder/MDX/JSON generation:

1. Delete all folders before build (except some files, in this case, `intro.mdx`).
2. Create folders before build (so that we don't have to `stat` for each MDX generation).
3. The rest is mostly the same as before, but at the end, we generate the `_category_.yml` on the `docs/wkt` folder.

![image](https://user-images.githubusercontent.com/7077157/151737333-67104b1b-c82a-40f2-b964-e7dddc0cb229.png)

Signed-off-by: Try Ajitiono <ballinst@gmail.com>