### PR TITLE
docs: implement MDX generation for RPC services

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+mdx/lib/test-resources

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+# This is so that the MDX aren't formatted when we save it.
 mdx/lib/test-resources

--- a/mdx/emit.ts
+++ b/mdx/emit.ts
@@ -66,9 +66,8 @@ const CATEGORY_LABELS = {
 
   for (const pkg of localPackages) {
     // Since services require the information of all messages, then
-    // we can only "render" the service string here. This is because,
-    // services request type and response type _can_ be a crosslink
-    // from other files in the same package.
+    // we can only "render" the service string here, after all messages
+    // have been identified.
     pkg.servicesData = pkg.rawProtoServices.map((service) => ({
       name: service.name,
       packageName: pkg.name,
@@ -83,11 +82,6 @@ const CATEGORY_LABELS = {
     // Emit messages and services.
     const pathToMessagesMdx = `${PATH_TO_MDX_FOLDER}/${pkg.name}`;
     promises.push(emitMdx(pathToMessagesMdx, pkg));
-
-    // Emit services.
-    // TODO(imballinst): remove this when we have emitted messages and services along together.
-    // const pathToServicesMdx = `${PATH_TO_MDX_FOLDER}/${pkg.name}`;
-    // promises.push(emitMdx(pathToServicesMdx, pkg, "servicesData"));
 
     // Emit JSON dictionary for the plugin.
     const pathToPlugin = `${PATH_TO_PLUGIN_DICTIONARY_FOLDER}/${pkg.name}`;
@@ -133,7 +127,6 @@ const CATEGORY_LABELS = {
   );
 
   // Create the metadata file.
-  // Add more to this array as needed later.
   promises.push(
     emitCategoryMetadata(PATH_TO_WKT_MDX_FOLDER, CATEGORY_LABELS.wkt)
   );

--- a/mdx/emit.ts
+++ b/mdx/emit.ts
@@ -33,6 +33,8 @@ const PRESERVED_DOCS_FILES = ["intro.mdx"];
 // Labels for the local types and the well-known types.
 const CATEGORY_LABELS = {
   wkt: "Well Known Types",
+  messages: "Messages",
+  services: "Services",
 };
 
 (async () => {
@@ -138,6 +140,8 @@ const CATEGORY_LABELS = {
   // Add more to this array as needed later.
   promises.push([
     emitCategoryMetadata(PATH_TO_WKT_MDX_FOLDER, CATEGORY_LABELS.wkt),
+    emitCategoryMetadata(PATH_TO_MESSAGES_MDX_FOLDER, CATEGORY_LABELS.messages),
+    emitCategoryMetadata(PATH_TO_SERVICES_MDX_FOLDER, CATEGORY_LABELS.services),
   ]);
 
   await Promise.all(promises);

--- a/mdx/lib/doc-to-mdx.test.ts
+++ b/mdx/lib/doc-to-mdx.test.ts
@@ -5,64 +5,104 @@ import { readFile } from "fs-extra";
 import { convertProtoToRecord } from "./record";
 
 const ROOT_PATH = path.join(__dirname, "../../");
-const BOOKING_DOC_JSON_PATH = path.join(
-  ROOT_PATH,
-  "website/generated/booking/v1/doc.json"
-);
-const BOOKING_MDX_EXPECTED_MESSAGES_RESULT_PATH = path.join(
-  __dirname,
-  "test-resources/booking-messages.mdx"
-);
-const BOOKING_MDX_EXPECTED_SERVICES_RESULT_PATH = path.join(
-  __dirname,
-  "test-resources/booking-services.mdx"
-);
 
-test("convertPackageToMdx", async () => {
-  const { packageData: packages, rawProtoMessages } = await convertPackageToMdx(
-    BOOKING_DOC_JSON_PATH
+describe("convertPackageToMdx", () => {
+  // Test messages.
+  const BOOKING_DOC_JSON_PATH = path.join(
+    ROOT_PATH,
+    "website/generated/booking/v1/doc.json"
   );
-  const localProtoMessagesDictionary = convertProtoToRecord(rawProtoMessages);
+  const BOOKING_MDX_EXPECTED_MESSAGES_PATH = path.join(
+    __dirname,
+    "test-resources/booking-messages.mdx"
+  );
 
-  const allMessages: string[] = [];
-  const allServices: string[] = [];
+  test("messages", async () => {
+    const { packageData: packages } = await convertPackageToMdx(
+      BOOKING_DOC_JSON_PATH
+    );
+    const allMessages: string[] = [];
 
-  for (const pkg of packages) {
-    for (const msgData of pkg.messagesData) {
-      allMessages.push(msgData.body);
+    for (const pkg of packages) {
+      for (const msgData of pkg.messagesData) {
+        allMessages.push(msgData.body);
+      }
     }
 
-    const array = pkg.rawProtoServices.map((service) =>
-      getServiceString({
-        service,
-        allProtoMessages: localProtoMessagesDictionary,
-        allWktMessages: {},
-        packageName: pkg.name,
-      })
+    const msgResult = allMessages.join("\n\n");
+    const expectedMsg = await readFile(
+      BOOKING_MDX_EXPECTED_MESSAGES_PATH,
+      "utf-8"
     );
 
-    allServices.push(...array);
-  }
+    assert.equal(msgResult.trim(), expectedMsg.trim());
+  });
 
-  // Messages.
-  const msgResult = allMessages.join("\n\n");
-  const expectedMsg = await readFile(
-    BOOKING_MDX_EXPECTED_MESSAGES_RESULT_PATH,
-    "utf-8"
+  // Test inner messages.
+  const LOCATION_DOC_JSON_PATH = path.join(
+    ROOT_PATH,
+    "website/generated/location/v1/doc.json"
+  );
+  const LOCATION_MDX_EXPECTED_MESSAGES_PATH = path.join(
+    __dirname,
+    "test-resources/location-messages.mdx"
   );
 
-  // Slice the last trailing CRLF from the `expectedMsg` variable.
-  // This is because each file is expectedMsg to have a trailing new line.
-  assert.equal(msgResult.trim(), expectedMsg.trim());
+  test("inner messages", async () => {
+    const { packageData: packages } = await convertPackageToMdx(
+      LOCATION_DOC_JSON_PATH
+    );
+    const allMessages: string[] = [];
 
-  // Services.
-  const svcResult = allServices.join("\n\n");
-  const expectedSvc = await readFile(
-    BOOKING_MDX_EXPECTED_SERVICES_RESULT_PATH,
-    "utf-8"
+    for (const pkg of packages) {
+      for (const msgData of pkg.messagesData) {
+        allMessages.push(msgData.body);
+      }
+    }
+
+    const msgResult = allMessages.join("\n\n");
+    const expectedMsg = await readFile(
+      LOCATION_MDX_EXPECTED_MESSAGES_PATH,
+      "utf-8"
+    );
+
+    assert.equal(msgResult.trim(), expectedMsg.trim());
+  });
+
+  // Test services.
+  const BOOKING_MDX_EXPECTED_SERVICES_PATH = path.join(
+    __dirname,
+    "test-resources/booking-services.mdx"
   );
 
-  // Slice the last trailing CRLF from the `expectedSvc` variable.
-  // This is because each file is expectedSvc to have a trailing new line.
-  assert.equal(svcResult.trim(), expectedSvc.trim());
+  test("services", async () => {
+    const { packageData: packages, rawProtoMessages } =
+      await convertPackageToMdx(BOOKING_DOC_JSON_PATH);
+    const localProtoMessagesDictionary = convertProtoToRecord(rawProtoMessages);
+    const allServices: string[] = [];
+
+    for (const pkg of packages) {
+      const array = pkg.rawProtoServices.map((service) =>
+        getServiceString({
+          service,
+          allProtoMessages: localProtoMessagesDictionary,
+          allWktMessages: {},
+          packageName: pkg.name,
+        })
+      );
+
+      allServices.push(...array);
+    }
+
+    // Services.
+    const svcResult = allServices.join("\n\n");
+    const expectedSvc = await readFile(
+      BOOKING_MDX_EXPECTED_SERVICES_PATH,
+      "utf-8"
+    );
+
+    // Slice the last trailing CRLF from the `expectedSvc` variable.
+    // This is because each file is expectedSvc to have a trailing new line.
+    assert.equal(svcResult.trim(), expectedSvc.trim());
+  });
 });

--- a/mdx/lib/doc-to-mdx.test.ts
+++ b/mdx/lib/doc-to-mdx.test.ts
@@ -1,33 +1,68 @@
-import { convertPackageToMdx } from "./doc-to-mdx";
+import { convertPackageToMdx, getServiceString } from "./doc-to-mdx";
 import path from "path";
 import assert from "assert";
 import { readFile } from "fs-extra";
+import { convertProtoToRecord } from "./record";
 
 const ROOT_PATH = path.join(__dirname, "../../");
 const BOOKING_DOC_JSON_PATH = path.join(
   ROOT_PATH,
   "website/generated/booking/v1/doc.json"
 );
-const BOOKING_MDX_EXPECTED_RESULT_PATH = path.join(
+const BOOKING_MDX_EXPECTED_MESSAGES_RESULT_PATH = path.join(
   __dirname,
-  "test-resources/booking.mdx"
+  "test-resources/booking-messages.mdx"
+);
+const BOOKING_MDX_EXPECTED_SERVICES_RESULT_PATH = path.join(
+  __dirname,
+  "test-resources/booking-services.mdx"
 );
 
 test("convertPackageToMdx", async () => {
-  const { packageData: packages } = await convertPackageToMdx(
+  const { packageData: packages, rawProtoMessages } = await convertPackageToMdx(
     BOOKING_DOC_JSON_PATH
   );
+  const localProtoMessagesDictionary = convertProtoToRecord(rawProtoMessages);
+
   const allMessages: string[] = [];
+  const allServices: string[] = [];
 
   for (const pkg of packages) {
     for (const msgData of pkg.messagesData) {
-      allMessages.push(msgData.messageStrings);
+      allMessages.push(msgData.body);
     }
-  }
-  const result = allMessages.join("\n\n");
-  const expected = await readFile(BOOKING_MDX_EXPECTED_RESULT_PATH, "utf-8");
 
-  // Slice the last trailing CRLF from the `expected` variable.
-  // This is because each file is expected to have a trailing new line.
-  assert.equal(result, expected.slice(0, -1));
+    const array = pkg.rawProtoServices.map((service) =>
+      getServiceString({
+        service,
+        allProtoMessages: localProtoMessagesDictionary,
+        allWktMessages: {},
+        packageName: pkg.name,
+      })
+    );
+
+    allServices.push(...array);
+  }
+
+  // Messages.
+  const msgResult = allMessages.join("\n\n");
+  const expectedMsg = await readFile(
+    BOOKING_MDX_EXPECTED_MESSAGES_RESULT_PATH,
+    "utf-8"
+  );
+
+  // Slice the last trailing CRLF from the `expectedMsg` variable.
+  // This is because each file is expectedMsg to have a trailing new line.
+  assert.equal(msgResult.trim(), expectedMsg.trim());
+
+  // Services.
+  const svcResult = allServices.join("\n\n");
+  const expectedSvc = await readFile(
+    BOOKING_MDX_EXPECTED_SERVICES_RESULT_PATH,
+    "utf-8"
+  );
+
+  // Slice the last trailing CRLF from the `expectedSvc` variable.
+  // This is because each file is expectedSvc to have a trailing new line.
+  assert.equal(svcResult.trim(), expectedSvc.trim());
 });

--- a/mdx/lib/doc-to-mdx.test.ts
+++ b/mdx/lib/doc-to-mdx.test.ts
@@ -14,7 +14,9 @@ const BOOKING_MDX_EXPECTED_RESULT_PATH = path.join(
 );
 
 test("convertPackageToMdx", async () => {
-  const packages = await convertPackageToMdx(BOOKING_DOC_JSON_PATH);
+  const { packageData: packages } = await convertPackageToMdx(
+    BOOKING_DOC_JSON_PATH
+  );
   const allMessages: string[] = [];
 
   for (const pkg of packages) {

--- a/mdx/lib/doc-to-mdx.ts
+++ b/mdx/lib/doc-to-mdx.ts
@@ -91,9 +91,9 @@ export async function emitMessagesJson({
   for (const message of messages) {
     const { name, packageName, hash } = message;
     // For example:
-    // If it's not WKT, then it's /docs/messages/booking.v1#Booking.
+    // If it's not WKT, then it's /docs/booking.v1#Booking.
     // If it's WKT, then it's /docs/wkt/google.protobuf#Int32.
-    map[name] = `/docs/${isWkt ? "wkt" : ""}/${packageName}#${hash}`;
+    map[name] = `/docs/${isWkt ? "wkt/" : ""}${packageName}#${hash}`;
   }
 
   return writeFile(`${filePath}.json`, JSON.stringify(map));

--- a/mdx/lib/doc-to-mdx.ts
+++ b/mdx/lib/doc-to-mdx.ts
@@ -84,6 +84,9 @@ export async function emitMdx(filePath: string, pkg: PackageData) {
   const services = pkg.servicesData.map((m) => m.body).join("\n\n");
   const messages = pkg.messagesData.map((m) => m.body).join("\n\n");
 
+  const servicesString = services.length ? `## Services\n\n${services}` : "";
+  const messagesString = messages.length ? `## Messages\n\n${messages}` : "";
+
   return writeFile(
     `${filePath}.mdx`,
     `
@@ -101,9 +104,7 @@ import RpcMethodText from "@theme/RpcMethodText";
 
 ${getPackageDescription(pkg)}
 
-${services}
-
-${messages}\n`.trimStart()
+${servicesString}${messagesString}\n`.trimStart()
   );
 }
 
@@ -152,7 +153,7 @@ export function getServiceString({
 
 <DefinitionHeader name="service">
 
-## ${service.name}
+### ${service.name}
 
 </DefinitionHeader>
 
@@ -222,10 +223,10 @@ function getMessageHeading(
   if (isLongVersion) {
     if (parentMessage) {
       // Set heading 3 for submessages.
-      heading = `### ${parentMessage}.${name}`;
+      heading = `#### ${parentMessage}.${name}`;
     } else {
       // Otherwise, heading 2.
-      heading = `## ${name}`;
+      heading = `### ${name}`;
     }
   }
 
@@ -347,7 +348,7 @@ function getServiceMethodString({
   responseTypePrefix="${responseStreaming ? "stream" : ""}"
   responseType="${responseType}">
 
-### ${name}
+#### ${name}
 
 </RpcDefinitionHeader>
 

--- a/mdx/lib/doc-to-mdx.ts
+++ b/mdx/lib/doc-to-mdx.ts
@@ -93,7 +93,7 @@ export async function emitMessagesJson({
     // For example:
     // If it's not WKT, then it's /docs/messages/booking.v1#Booking.
     // If it's WKT, then it's /docs/wkt/google.protobuf#Int32.
-    map[name] = `/docs/${isWkt ? "wkt" : "messages"}/${packageName}#${hash}`;
+    map[name] = `/docs/${isWkt ? "wkt" : ""}/${packageName}#${hash}`;
   }
 
   return writeFile(`${filePath}.json`, JSON.stringify(map));

--- a/mdx/lib/doc-to-mdx.ts
+++ b/mdx/lib/doc-to-mdx.ts
@@ -334,7 +334,7 @@ function getField(field: Field, num: number, level: number) {
 
 function getCommentString(comment: string, prefix: string) {
   if (comment === "") {
-    return "\n";
+    return "";
   }
 
   const lines = comment.split("\n");

--- a/mdx/lib/record.ts
+++ b/mdx/lib/record.ts
@@ -1,0 +1,13 @@
+import { ProtoMessage } from "./types";
+
+export function convertProtoToRecord(
+  messages: ProtoMessage[]
+): Record<string, ProtoMessage> {
+  const record: Record<string, ProtoMessage> = {};
+
+  for (const message of messages) {
+    record[message.name] = message;
+  }
+
+  return record;
+}

--- a/mdx/lib/test-resources/booking-messages.mdx
+++ b/mdx/lib/test-resources/booking-messages.mdx
@@ -25,8 +25,10 @@ message Booking {
   // Color preference of the customer.
   string color_preference = 6;
   // Pick-up location.
+  // This is a coordinate.
   Location pickup_location = 7;
   // Destination location.
+  // This is a coordinate.
   Location destination_location = 8;
 }
 ```

--- a/mdx/lib/test-resources/booking-messages.mdx
+++ b/mdx/lib/test-resources/booking-messages.mdx
@@ -2,7 +2,7 @@
 
 <DefinitionHeader name="message">
 
-## Booking
+### Booking
 
 </DefinitionHeader>
 
@@ -39,7 +39,7 @@ message Booking {
 
 <DefinitionHeader name="message">
 
-## BookingStatus
+### BookingStatus
 
 </DefinitionHeader>
 
@@ -62,7 +62,7 @@ message BookingStatus {
 
 <DefinitionHeader name="message">
 
-## BookingStatusID
+### BookingStatusID
 
 </DefinitionHeader>
 
@@ -81,7 +81,7 @@ message BookingStatusID {
 
 <DefinitionHeader name="message">
 
-## EmptyBookingMessage
+### EmptyBookingMessage
 
 </DefinitionHeader>
 

--- a/mdx/lib/test-resources/booking-services.mdx
+++ b/mdx/lib/test-resources/booking-services.mdx
@@ -2,7 +2,7 @@
 
 <DefinitionHeader name="service">
 
-## BookingService
+### BookingService
 
 </DefinitionHeader>
 
@@ -16,7 +16,7 @@ Service for handling vehicle bookings.
   responseTypePrefix=""
   responseType="BookingStatus">
 
-### BookVehicle
+#### BookVehicle
 
 </RpcDefinitionHeader>
 
@@ -89,7 +89,7 @@ message BookingStatus {
   responseTypePrefix="stream"
   responseType="BookingStatus">
 
-### BookingUpdates
+#### BookingUpdates
 
 </RpcDefinitionHeader>
 

--- a/mdx/lib/test-resources/booking-services.mdx
+++ b/mdx/lib/test-resources/booking-services.mdx
@@ -1,0 +1,140 @@
+<Definition>
+
+<DefinitionHeader name="service">
+
+## BookingService
+
+</DefinitionHeader>
+
+Service for handling vehicle bookings.
+
+<RpcDefinition>
+
+<RpcDefinitionHeader
+  requestTypePrefix=""
+  requestType="Booking"
+  responseTypePrefix=""
+  responseType="BookingStatus">
+
+### BookVehicle
+
+</RpcDefinitionHeader>
+
+<RpcDefinitionDescription>
+
+Used to book a vehicle. Pass in a Booking and a BookingStatus will be
+returned.
+
+<RpcMethodText type="request" isStream={false}>
+  Booking
+</RpcMethodText>
+
+<Definition>
+
+
+
+```protosaurus--booking.v1.Booking
+message Booking {
+  // ID of booked vehicle.
+  int32 vehicle_id = 1;
+  // Customer that booked the vehicle.
+  int32 customer_id = 2;
+  // Status of the booking.
+  BookingStatus status = 3;
+  // Has booking confirmation been sent.
+  bool confirmation_sent = 4;
+  // Has payment been received.
+  bool payment_received = 5;
+  // Color preference of the customer.
+  string color_preference = 6;
+  // Pick-up location.
+  // This is a coordinate.
+  Location pickup_location = 7;
+  // Destination location.
+  // This is a coordinate.
+  Location destination_location = 8;
+}
+```
+
+</Definition>
+
+<RpcMethodText type="response" isStream={false}>BookingStatus</RpcMethodText>
+
+<Definition>
+
+
+
+```protosaurus--booking.v1.BookingStatus
+message BookingStatus {
+  // Unique booking status ID.
+  int32 id = 1;
+  // Booking status description. E.g. "Active".
+  string description = 2;
+  // Duration.
+  Duration duration = 3;
+}
+```
+
+</Definition>
+
+</RpcDefinitionDescription>
+
+</RpcDefinition>
+
+<RpcDefinition>
+
+<RpcDefinitionHeader
+  requestTypePrefix=""
+  requestType="BookingStatusID"
+  responseTypePrefix="stream"
+  responseType="BookingStatus">
+
+### BookingUpdates
+
+</RpcDefinitionHeader>
+
+<RpcDefinitionDescription>
+
+Used to subscribe to updates of the BookingStatus.
+
+<RpcMethodText type="request" isStream={false}>
+  BookingStatusID
+</RpcMethodText>
+
+<Definition>
+
+
+
+```protosaurus--booking.v1.BookingStatusID
+message BookingStatusID {
+  // Unique booking status ID.
+  int32 id = 1;
+}
+```
+
+</Definition>
+
+<RpcMethodText type="response" isStream={true}>BookingStatus</RpcMethodText>
+
+<Definition>
+
+
+
+```protosaurus--booking.v1.BookingStatus
+message BookingStatus {
+  // Unique booking status ID.
+  int32 id = 1;
+  // Booking status description. E.g. "Active".
+  string description = 2;
+  // Duration.
+  Duration duration = 3;
+}
+```
+
+</Definition>
+
+</RpcDefinitionDescription>
+
+</RpcDefinition>
+
+</Definition>

--- a/mdx/lib/test-resources/location-messages.mdx
+++ b/mdx/lib/test-resources/location-messages.mdx
@@ -1,0 +1,32 @@
+<Definition>
+
+<DefinitionHeader name="message">
+
+### Location
+
+</DefinitionHeader>
+
+Sample location.
+
+```protosaurus--location.v1.Location
+message Location {
+  // Latitude of the location.
+  int32 latitude = 1;
+  // Longitude of the location.
+  int32 longitude = 2;
+  // Address (human-friendly string) of the location.
+  string address = 3;
+
+  message InnerMessage {
+    // Sample integer.
+    int32 hello = 1;
+  }
+
+  // Sample message.
+  InnerMessage inner_message = 4;
+  // Sample message yet again.
+  InnerMessage second_inner = 5;
+}
+```
+
+</Definition>

--- a/mdx/lib/test-resources/location-messages.mdx
+++ b/mdx/lib/test-resources/location-messages.mdx
@@ -26,6 +26,7 @@ message Location {
   InnerMessage inner_message = 4;
   // Sample message yet again.
   InnerMessage second_inner = 5;
+  InnerMessage empty_comment = 6;
 }
 ```
 

--- a/mdx/lib/types.ts
+++ b/mdx/lib/types.ts
@@ -81,6 +81,7 @@ export interface PackageData {
   name: string;
   description: string;
   messagesData: MessageData[];
+  innerMessagesRecord: Record<string, string>;
   servicesData: ServiceData[];
   // Raw proto services.
   rawProtoServices: ProtoService[];

--- a/mdx/lib/types.ts
+++ b/mdx/lib/types.ts
@@ -1,0 +1,87 @@
+export interface Protofile {
+  name: string;
+  title: string;
+  description: string;
+  package: string;
+  hasEnums: false;
+  hasExtensions: boolean;
+  hasMessages: boolean;
+  hasServices: boolean;
+  // TODO(imballinst): create proper typing.
+  enums: any;
+  extensions: any;
+  messages: ProtoMessage[];
+  services: ProtoService[];
+}
+
+export interface ProtoMessage {
+  name: string;
+  longName: string;
+  fullName: string;
+  description: string;
+  hasExtensions: boolean;
+  hasFields: boolean;
+  hasOneofs: boolean;
+  extensions: any[];
+  fields: Field[];
+}
+
+export interface Field {
+  name: string;
+  description: string;
+  label: string;
+  type: string;
+  longType: string;
+  fullType: string;
+  ismap: boolean;
+  isoneof: boolean;
+  oneofdecl: string;
+  defaultValue: string;
+  options?: {
+    [index: string]: any;
+  };
+}
+
+export interface ServiceMethod {
+  name: string;
+  description: string;
+  requestType: string;
+  requestLongType: string;
+  requestFullType: string;
+  requestStreaming: boolean;
+  responseType: string;
+  responseLongType: string;
+  responseFullType: string;
+  responseStreaming: boolean;
+  options: any;
+}
+
+export interface ProtoService {
+  name: string;
+  longName: string;
+  fullName: string;
+  description: string;
+  methods: ServiceMethod[];
+}
+
+export interface MessageData {
+  name: string;
+  packageName: string;
+  hash: string;
+  body: string;
+}
+
+export interface ServiceData {
+  name: string;
+  packageName: string;
+  body: string;
+}
+
+export interface PackageData {
+  name: string;
+  description: string;
+  messagesData: MessageData[];
+  servicesData: ServiceData[];
+  // Raw proto services.
+  rawProtoServices: ProtoService[];
+}

--- a/testdata/booking/v1/booking.proto
+++ b/testdata/booking/v1/booking.proto
@@ -64,9 +64,11 @@ message Booking {
   string color_preference = 6 [deprecated = true];
 
   // Pick-up location.
+  // This is a coordinate.
   location.v1.Location pickup_location = 7;
 
   // Destination location.
+  // This is a coordinate.
   location.v1.Location destination_location = 8;
 }
 

--- a/testdata/location/v1/location.proto
+++ b/testdata/location/v1/location.proto
@@ -43,4 +43,7 @@ message Location {
 
   // Sample message yet again.
   InnerMessage second_inner = 5;
+
+  //
+  InnerMessage empty_comment = 6;
 }

--- a/testdata/location/v1/location.proto
+++ b/testdata/location/v1/location.proto
@@ -40,4 +40,7 @@ message Location {
 
   // Sample message.
   InnerMessage inner_message = 4;
+
+  // Sample message yet again.
+  InnerMessage second_inner = 5;
 }

--- a/website/src/theme/Definition.module.css
+++ b/website/src/theme/Definition.module.css
@@ -61,12 +61,17 @@
   padding: 8px;
 }
 
+.rpc-definition-description > .definition > .definition-title {
+  margin-top: 0;
+}
+
 .rpc-definition-description > p:last-child {
   margin-bottom: 0;
 }
 
 .rpc-method-options {
   color: var(--ifm-color-gray-600);
+  margin-right: 8px;
 }
 
 .rpc-method-options-stream {

--- a/website/src/theme/Definition.module.css
+++ b/website/src/theme/Definition.module.css
@@ -64,3 +64,13 @@
 .rpc-definition-description > p:last-child {
   margin-bottom: 0;
 }
+
+.rpc-method-options {
+  color: var(--ifm-color-gray-600);
+}
+
+.rpc-method-options-stream {
+  border: 1px solid var(--ifm-color-gray-600);
+  border-radius: 16px;
+  color: var(--ifm-color-info);
+}

--- a/website/src/theme/Definition.module.css
+++ b/website/src/theme/Definition.module.css
@@ -4,7 +4,7 @@
  */
 
 /* Messages. */
-.definition {
+.definition:not(:last-child) {
   margin-bottom: var(--ifm-paragraph-margin-bottom);
 }
 
@@ -12,10 +12,10 @@
   margin-bottom: calc(
     var(--ifm-heading-vertical-rhythm-bottom) * var(--ifm-leading)
   );
-  margin-top: calc(var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
+  margin-top: calc(var(--ifm-h3-vertical-rhythm-top) * var(--ifm-leading));
 }
 
-.definition-title h2 {
+.definition-title h3 {
   scroll-margin-top: calc(var(--ifm-navbar-height) + 2rem);
 }
 
@@ -26,12 +26,11 @@
 /* Services. */
 .rpc-definition {
   margin-bottom: var(--ifm-paragraph-margin-bottom);
-  border-top: none;
-  border: 1px solid var(--ifm-toc-border-color);
   border-radius: 4px;
 }
 
 .rpc-definition-title {
+  border-top: 1px solid var(--ifm-toc-border-color);
   border-bottom: 1px solid var(--ifm-toc-border-color);
   padding: 8px;
 }
@@ -44,12 +43,12 @@
   content: " ";
 }
 
-.rpc-definition-name h3 {
+.rpc-definition-name h4 {
   display: inline;
   font-size: 1rem;
 }
 
-.rpc-definition-name h3 a {
+.rpc-definition-name h4 a {
   display: none;
 }
 
@@ -69,6 +68,10 @@
   margin-bottom: 0;
 }
 
+.rpc-method {
+  margin-bottom: 4px;
+}
+
 .rpc-method-options {
   color: var(--ifm-color-gray-600);
   margin-right: 8px;
@@ -78,4 +81,6 @@
   border: 1px solid var(--ifm-color-gray-600);
   border-radius: 16px;
   color: var(--ifm-color-info);
+  margin-left: 8px;
+  padding: 2px 8px;
 }

--- a/website/src/theme/RpcDefinitionHeader.js
+++ b/website/src/theme/RpcDefinitionHeader.js
@@ -17,8 +17,10 @@ export default function DefinitionHeader({
         <span>rpc</span> {children}
       </div>
 
-      <Type prefix={requestTypePrefix}>({requestType})</Type>
-      <Type prefix={responseTypePrefix}>returns ({responseType})</Type>
+      <Type prefix={requestTypePrefix}>{requestType}</Type>
+
+      <span> returns</span>
+      <Type prefix={responseTypePrefix}>{responseType}</Type>
     </div>
   );
 }
@@ -26,7 +28,7 @@ export default function DefinitionHeader({
 function Type({ prefix, children }) {
   let prefixJsx;
 
-  if (prefix !== undefined) {
+  if (prefix) {
     prefixJsx = (
       <>
         <span>{prefix}</span>{" "}
@@ -36,8 +38,8 @@ function Type({ prefix, children }) {
 
   return (
     <div>
-      {prefixJsx}
-      {children}
+      ({prefixJsx}
+      {children})
     </div>
   );
 }

--- a/website/src/theme/RpcMethodText.js
+++ b/website/src/theme/RpcMethodText.js
@@ -6,7 +6,7 @@ import styles from "./Definition.module.css";
 
 export default function RpcMethodText({ type, isStream, children }) {
   return (
-    <div>
+    <div className={styles["rpc-method"]}>
       <span className={styles["rpc-method-options"]}>{type}</span>
       {children}
       {isStream ? (

--- a/website/src/theme/RpcMethodText.js
+++ b/website/src/theme/RpcMethodText.js
@@ -6,8 +6,8 @@ import styles from "./Definition.module.css";
 
 export default function RpcMethodText({ type, isStream, children }) {
   return (
-    <div className={styles["rpc-method-options"]}>
-      <span>{type}</span>
+    <div>
+      <span className={styles["rpc-method-options"]}>{type}</span>
       {children}
       {isStream ? (
         <span className={styles["rpc-method-options-stream"]}>stream</span>

--- a/website/src/theme/RpcMethodText.js
+++ b/website/src/theme/RpcMethodText.js
@@ -1,0 +1,17 @@
+// Copyright 2022 Protosaurus Authors
+// Licensed under the Apache License, Version 2.0 (the "License")
+
+import React from "react";
+import styles from "./Definition.module.css";
+
+export default function RpcMethodText({ type, isStream, children }) {
+  return (
+    <div className={styles["rpc-method-options"]}>
+      <span>{type}</span>
+      {children}
+      {isStream ? (
+        <span className={styles["rpc-method-options-stream"]}>stream</span>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR implements MDX generation and rendering for the RPC services. Included in this PR:

- [x] Styling to the RPC services (styling to the code block probably in the next PR)
- [x] Merge services and messages under one root package
- [x] Render inner message in the list of fields directly instead of adding a new heading
- [x] Empty comments will now not be rendered
- [x] Fix indentations for multiline comments

## Key changes

There are some changes on the functions in this PR. Primarily because in rendering the Protobuf services, we most likely need all messages (from all packages) to be identified first, so that they can be crosslinked.

Since now we also include services and messages in a page, then the previous headings are incremented by 1:

- Heading 2 is for "Services" and "Messages"
- Heading 3 is for Services/Messages
- Heading 4 at the moment is for Service Methods

## Video

https://user-images.githubusercontent.com/7077157/152113044-35e9ea4b-fb71-4f6e-a31d-473fd9431f6e.mov

## Future works

- Cleanups. The MDX generation module, in particular, is pretty messy and might be hard to read/use.
- Improve styling of the code block. I'm unsure if we can convert the `protosaurus--{namespace}` language to just `proto` and what kind of effect it will have, but I think it's worth a try.