### PR TITLE
fix: fix multiline links not rendering properly

### DIFF
--- a/mdx/lib/messages.test.ts
+++ b/mdx/lib/messages.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { getFieldComment } from "./messages";
+
+describe("getFieldComment", () => {
+  test("without link", () => {
+    const sampleText = `
+Hello world! This is a comment without link.
+As a bonus, I give you a multi-line example.
+    `.trim();
+
+    expect(getFieldComment(sampleText, "").trim()).to.equal(
+      `
+// Hello world! This is a comment without link.
+// As a bonus, I give you a multi-line example.
+    `.trim()
+    );
+  });
+
+  test("link", () => {
+    const sampleText = `
+Hello world! This is a comment [with link](https://example.com).
+As a bonus, I give you a multi-line example.
+    `.trim();
+
+    expect(getFieldComment(sampleText, "").trim()).to.equal(
+      `
+// Hello world! This is a comment [with link](https://example.com).
+// As a bonus, I give you a multi-line example.
+    `.trim()
+    );
+  });
+
+  test("link and new line", () => {
+    const sampleText = `
+Hello world! This is a comment with [link separated
+by a newline](https://example.com).
+As a bonus, I give you a multi-line example.
+      `.trim();
+
+    expect(getFieldComment(sampleText, "").trim()).to.equal(
+      `
+// Hello world! This is a comment with [link separated by a newline](https://example.com).
+// As a bonus, I give you a multi-line example.
+      `.trim()
+    );
+  });
+
+  test("link and new line in the middle of a sentence", () => {
+    const sampleText = `
+Hello world! This is a comment with [link separated
+by a newline](https://example.com) in the middle of a sentence.
+As a bonus, I give you a multi-line example.
+  `.trim();
+
+    expect(getFieldComment(sampleText, "").trim()).to.equal(
+      `
+// Hello world! This is a comment with [link separated by a newline](https://example.com)
+// in the middle of a sentence.
+// As a bonus, I give you a multi-line example.
+  `.trim()
+    );
+  });
+
+  test("a lot of links with new line in the middle of a sentence", () => {
+    const sampleText = `
+Hello world! This is a comment with [link separated
+by a newline](https://example.com) in the middle of a sentence.
+Hello world! This is a comment with [link separated
+by a newline](https://example.com) in the middle of a sentence.
+As a bonus, I give you a multi-line example.
+  `.trim();
+
+    expect(getFieldComment(sampleText, "").trim()).to.equal(
+      `
+// Hello world! This is a comment with [link separated by a newline](https://example.com)
+// in the middle of a sentence.
+// Hello world! This is a comment with [link separated by a newline](https://example.com)
+// in the middle of a sentence.
+// As a bonus, I give you a multi-line example.
+  `.trim()
+    );
+  });
+});

--- a/mdx/lib/messages.ts
+++ b/mdx/lib/messages.ts
@@ -118,6 +118,22 @@ export function getMessageFieldsBlock({
   return `${prefixSpaces}message ${name} ${fieldsBlock}`;
 }
 
+export function getFieldComment(comment: string, linePrefix: string) {
+  if (comment === "") {
+    return "";
+  }
+
+  const parsed = cleanupComment(comment);
+  const lines = parsed.split("\n");
+  const length = lines.length;
+
+  for (let i = 0; i < length; i++) {
+    lines[i] = `${linePrefix}// ${lines[i]}`;
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 // Helper functions.
 function getFieldBlock({
   field,
@@ -140,7 +156,7 @@ function getFieldBlock({
   });
 
   return (
-    getCommentString(field.description, prefixSpaces) +
+    getFieldComment(field.description, prefixSpaces) +
     `${prefixSpaces}${fieldType} ${field.name} = ${num};`
   );
 }
@@ -183,15 +199,110 @@ function getIndentation(level: number) {
   return prefixSpaces;
 }
 
-function getCommentString(comment: string, linePrefix: string) {
-  if (comment === "") {
-    return "";
+// Let's define the rules.
+// A link CANNOT contain a space.
+// The hyperlinked text can contain anything, except double newlines.
+function cleanupComment(line: string) {
+  const length = line.length;
+  let result = "";
+  let i = 0;
+
+  while (i < length) {
+    let nextIndex = i + 1;
+    let textToAdd = line.charAt(i);
+
+    if (textToAdd === "[") {
+      // The "[" is the biggest indicator of a link.
+      const bracketParenthesisIndex = line.indexOf("](", i);
+
+      if (bracketParenthesisIndex > -1) {
+        // Exists. We then check for the closing parenthesis.
+        const closingParenthesisIndex = line.indexOf(")", i);
+
+        if (
+          i < bracketParenthesisIndex &&
+          bracketParenthesisIndex < closingParenthesisIndex
+        ) {
+          // The bracket parenthesis should be in the middle.
+          // Slice the text.
+          const text = line.slice(i + 1, bracketParenthesisIndex);
+          const link = line.slice(
+            bracketParenthesisIndex + 2,
+            closingParenthesisIndex
+          );
+
+          const isTextValid = !isCharacterRepeatedNTimesInARow({
+            text,
+            character: "\n",
+            maxTimesInARow: 2,
+          });
+          const isLinkValid = !isCharacterRepeatedNTimesInARow({
+            text: link,
+            character: " ",
+            maxTimesInARow: 1,
+          });
+
+          if (isTextValid && isLinkValid) {
+            // In text: 1 newline is still OK, but 2 is not.
+            // In link: spaces are not allowed.
+            textToAdd = `[${text}](${link})`;
+            nextIndex = closingParenthesisIndex + 1;
+
+            if (textToAdd.includes("\n")) {
+              textToAdd = textToAdd.replace("\n", " ");
+
+              // Replace the next whitespace to a newline to offset the newline we removed.
+              const match = /\s/.exec(line.slice(nextIndex));
+
+              if (match) {
+                const offset = match.index;
+                textToAdd += line.slice(nextIndex, nextIndex + offset);
+                textToAdd += "\n";
+                nextIndex += offset + 1;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    result += textToAdd;
+    i = nextIndex;
   }
 
-  const lines = comment.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    lines[i] = `${linePrefix}// ${lines[i]}`;
+  return result;
+}
+
+function isCharacterRepeatedNTimesInARow({
+  text,
+  character,
+  maxTimesInARow,
+}: {
+  text: string;
+  character: string;
+  maxTimesInARow: number;
+}) {
+  let count = 0;
+  let previousCharacter = "";
+  let i = 0;
+
+  while (i < text.length) {
+    const currentChar = text.charAt(i);
+    if (
+      character === currentChar &&
+      (previousCharacter === "" || previousCharacter === currentChar)
+    ) {
+      count++;
+
+      if (maxTimesInARow === count) {
+        // Early exit if exceeds.
+        break;
+      }
+    }
+
+    previousCharacter = currentChar;
+    i++;
   }
 
-  return `${lines.join("\n")}\n`;
+  return count === maxTimesInARow;
 }

--- a/mdx/lib/messages.ts
+++ b/mdx/lib/messages.ts
@@ -208,6 +208,9 @@ function cleanupComment(line: string) {
   let i = 0;
 
   while (i < length) {
+    // Since we can "jump" through the line (it's not always +1),
+    // then we need to declare it as a variable.
+    // For example, the [text](link) means we will skip 12 characters.
     let nextIndex = i + 1;
     let textToAdd = line.charAt(i);
 
@@ -216,14 +219,15 @@ function cleanupComment(line: string) {
       const bracketParenthesisIndex = line.indexOf("](", i);
 
       if (bracketParenthesisIndex > -1) {
-        // Exists. We then check for the closing parenthesis.
+        // Bracket and parenthesis exist.
+        // We then check for the closing parenthesis.
         const closingParenthesisIndex = line.indexOf(")", i);
 
         if (
           i < bracketParenthesisIndex &&
           bracketParenthesisIndex < closingParenthesisIndex
         ) {
-          // The bracket parenthesis should be in the middle.
+          // The bracket and parenthesis should be positioned in the middle.
           // Slice the text.
           const text = line.slice(i + 1, bracketParenthesisIndex);
           const link = line.slice(
@@ -256,8 +260,12 @@ function cleanupComment(line: string) {
 
               if (match) {
                 const offset = match.index;
+                // Append with the text until the next whitespace.
                 textToAdd += line.slice(nextIndex, nextIndex + offset);
+                // Append the newline.
                 textToAdd += "\n";
+                // Increase the next index by offset + 1 so that the whitespace
+                // won't be included in the next iteration.
                 nextIndex += offset + 1;
               }
             }

--- a/mdx/lib/test-resources/location-messages.mdx
+++ b/mdx/lib/test-resources/location-messages.mdx
@@ -20,6 +20,8 @@ message Location {
   // https://github.com tests line at the start.
   // This line tests for a link https://github.com at the middle.
   // This line tests for a [link inside comment](https://github.com) and https://github.com.
+  // This line tests for a [multi-line link inside a comment](https://github.com).
+  // Beware!
   string address = 3;
 
   message InnerMessage {

--- a/testdata/location/v1/location.proto
+++ b/testdata/location/v1/location.proto
@@ -35,6 +35,8 @@ message Location {
   // https://github.com tests line at the start.
   // This line tests for a link https://github.com at the middle.
   // This line tests for a [link inside comment](https://github.com) and https://github.com.
+  // This line tests for a [multi-line
+  // link inside a comment](https://github.com). Beware!
   string address = 3 [(google.api.field_behavior) = REQUIRED, (validate.rules).string.min_len = 1];
 
   // Sample InnerMessage to test submessages.


### PR DESCRIPTION
This PR fixes multiline links not being rendered properly. Thanks to @dio for the idea, here's how the "cleanup" works:

1. Parse each character one by one. I wanted to use RegEx, but RegEx is a bit hard to read for this case (at least for me), so I chose a rather manual way: parsing.
2. Check for the current character is a "[". If so, then we want to find the next "](" and ")" and see if they have the correct positions.
3. If the text doesn't have a link, then it renders as a normal text.
4. If the text does have a link, it renders as a link, normally.
5. If the text is a multi-line link, then we "merge" the multi-line into the same line. We replace the next whitespace with a newline to offset the newline that we merged previously.

All cases above are documented inside a test file. Let me know if you have suggestions!

![image](https://user-images.githubusercontent.com/7077157/153208571-7db3c128-fccf-44a4-99af-ca946e4d88dd.png)

Signed-off-by: Try Ajitiono <ballinst@gmail.com>