### PR TITLE
Build and "preview" website on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,5 +100,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '👋 you can check the preview on: https://imballinst.github.io/protosaurus/${{ steps.current-pr.outputs.pr }}/.'
+              body: '👋 you can check the preview on: https://imballinst.github.io/protosaurus/pr-${{ steps.current-pr.outputs.pr }}/.'
             })

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,6 @@ jobs:
       - name: Get current PR number
         if: ${{ github.ref != 'refs/heads/main' }}
         uses: jwalton/gh-find-current-pr@v1
-        if: ${{ github.ref != 'refs/heads/main' }}
         id: current-pr
 
       # The combination of this and the previous step overrides BASE_URL.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,8 +71,8 @@ jobs:
       - name: set BASE_URL on PR
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
-          echo "::set-env name=BASE_URL::pr-${{ steps.current-pr.outputs.pr }}"
-          echo "::set-env name=BASE_DIR::pr-${{ steps.current-pr.outputs.pr }}"
+          echo "BASE_URL=pr-${{ steps.current-pr.outputs.pr }}" >> $GITHUB_ENV
+          echo "BASE_DIR=pr-${{ steps.current-pr.outputs.pr }}" >> $GITHUB_ENV
 
       - run: make docs
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,8 +67,12 @@ jobs:
         uses: jwalton/gh-find-current-pr@v1
         id: current-pr
 
+      - name: Set repository name
+        run: |
+          echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
+
       # The combination of this and the previous step overrides BASE_URL.
-      - name: set BASE_DIR on PR
+      - name: Set BASE_DIR on PR
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           echo "BASE_DIR=pr-${{ steps.current-pr.outputs.pr }}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,10 +81,24 @@ jobs:
           cp -r website/build builds/${BASE_DIR}
           cp -f index.html builds/index.html
 
-      - uses: peaceiris/actions-gh-pages@v3
+      - name: Publish all sites
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ github.token }}
           publish_dir: builds/
           # This allows you to make your publish branch with only the latest commit.
           # https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan.
           force_orphan: true
+
+      - name: Send message to the PR submitter
+        uses: actions/github-script@v5
+        if: ${{ github.ref != 'refs/heads/main' }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '👋 you can check the preview on: https://imballinst.github.io/protosaurus/${{ steps.current-pr.outputs.pr }}/.'
+            })

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ defaults:
     shell: bash
 
 env:
+  # This will be added to the docusaurus.baseUrl, i.e. /protosaurus/${BASE_DIR}.
   # Reference: https://docusaurus.io/docs/api/docusaurus-config#baseurl.
-  BASE_URL: "/protosaurus/main/"
   BASE_DIR: "main"
 
 jobs:
@@ -68,10 +68,9 @@ jobs:
         id: current-pr
 
       # The combination of this and the previous step overrides BASE_URL.
-      - name: set BASE_URL on PR
+      - name: set BASE_DIR on PR
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
-          echo "BASE_URL=pr-${{ steps.current-pr.outputs.pr }}" >> $GITHUB_ENV
           echo "BASE_DIR=pr-${{ steps.current-pr.outputs.pr }}" >> $GITHUB_ENV
 
       - run: make docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,8 @@ defaults:
 
 env:
   # Reference: https://docusaurus.io/docs/api/docusaurus-config#baseurl.
-  WEBSITE_BASE_URL: "/protosaurus/"
+  BASE_URL: "/protosaurus/main/"
+  BASE_DIR: "main"
 
 jobs:
   gen:
@@ -31,6 +32,13 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
+
+      - name: Fetch current deployed website
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: builds
+
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
@@ -48,15 +56,37 @@ jobs:
           path: ./.cache/buf
           key: protosaurus-${{ runner.os }}-buf-${{ hashFiles('testdata/buf.lock') }}
           restore-keys: protosaurus-${{ runner.os }}-buf-
+
       - run: make gen
+
       # TODO(imballinst): not sure whether to put this test here or to create a new job.
       - run: make test
+
+      - name: Get current PR number
+        if: ${{ github.ref != 'refs/heads/main' }}
+        uses: jwalton/gh-find-current-pr@v1
+        if: ${{ github.ref != 'refs/heads/main' }}
+        id: current-pr
+
+      # The combination of this and the previous step overrides BASE_URL.
+      - name: set BASE_URL on PR
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "::set-env name=BASE_URL::pr-${{ steps.current-pr.outputs.pr }}"
+          echo "::set-env name=BASE_DIR::pr-${{ steps.current-pr.outputs.pr }}"
+
       - run: make docs
+
+      - name: Merge all sites
+        run: |
+          rm -fr builds/${BASE_DIR}
+          cp -r website/build builds/${BASE_DIR}
+          cp -f index.html builds/index.html
+
       - uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ github.token }}
-          publish_dir: website/build
+          publish_dir: builds/
           # This allows you to make your publish branch with only the latest commit.
           # https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan.
           force_orphan: true

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;url=https://imballinst.github.io/protosaurus/main" />

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -27,7 +27,7 @@ const {
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: `My Site (${process.env.BASE_DIR})`,
-  tagline: "Dinosaurs are cool",
+  tagline: "Dinosaurs are really cool",
   url: "https://your-docusaurus-test-site.com",
   baseUrl: process.env.BASE_DIR ? `/protosaurus/${process.env.BASE_DIR}/` : "/",
   onBrokenLinks: "throw",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -29,7 +29,7 @@ const config = {
   title: `My Site (${process.env.BASE_DIR})`,
   tagline: "Dinosaurs are really cool",
   url: "https://your-docusaurus-test-site.com",
-  baseUrl: process.env.BASE_DIR ? `/protosaurus/${process.env.BASE_DIR}/` : "/",
+  baseUrl: process.env.BASE_DIR ? `/${process.env.REPOSITORY_NAME || "protosaurus"}/${process.env.BASE_DIR}/` : "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -29,7 +29,7 @@ const config = {
   title: `My Site (${process.env.BASE_DIR})`,
   tagline: "Dinosaurs are cool",
   url: "https://your-docusaurus-test-site.com",
-  baseUrl: process.env.BASE_URL || "/",
+  baseUrl: process.env.BASE_DIR ? `/protosaurus/${process.env.BASE_DIR}/` : "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,10 +26,10 @@ const {
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "My Site",
+  title: `My Site (${process.env.BASE_DIR})`,
   tagline: "Dinosaurs are cool",
   url: "https://your-docusaurus-test-site.com",
-  baseUrl: process.env.WEBSITE_BASE_URL || "/",
+  baseUrl: process.env.BASE_URL || "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",


### PR DESCRIPTION
This builds and publishes the website on PR workflow, with /protosaurus/pr-<number> as the path.

This is a poor man previewer ❌💰.

Next, we need to have a scheduled cleanup-er, especially if we want to have a different (preview) subdirectory for each commit within a PR (which probably won't be needed until then, we can use a better platform?).

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>