### PR TITLE
fix: fix image not showing on subdirectory deployment

### DIFF
--- a/website/src/theme/ProtosaurusImage.tsx
+++ b/website/src/theme/ProtosaurusImage.tsx
@@ -28,7 +28,7 @@ export default function ProtosaurusImage() {
       const alt = element.dataset["imageAlt"];
 
       setModalInfo({
-        src,
+        src: require(`@site/static${src}`).default,
         alt,
         // Cleanup the slashes.
         id: `dialog-id-${src.replace(/\//g, "")}`,


### PR DESCRIPTION
This PR fixes image not showing on subdirectory deployment. As noted in https://docusaurus.io/docs/docusaurus-core#useBaseUrl, we are using this notation instead:

```
<img src={require('@site/static/img/myImage.png').default} />
```

![image](https://user-images.githubusercontent.com/7077157/153789306-c951a89d-c209-403f-be7f-2519e0b33f8b.png)

Signed-off-by: Try Ajitiono <ballinst@gmail.com>