### PR TITLE
packages: move rehype plugin to @protosaurus/docusaurus-preset

### DIFF
--- a/packages/docusaurus-preset/package.json
+++ b/packages/docusaurus-preset/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@docusaurus/preset-classic": "2.0.0-beta.15",
-    "@protosaurus/docusaurus-theme": "0.0.1"
+    "@protosaurus/docusaurus-theme": "0.0.1",
+    "@protosaurus/rehype-plugin-codeblock": "0.0.1"
   }
 }

--- a/packages/docusaurus-preset/src/index.ts
+++ b/packages/docusaurus-preset/src/index.ts
@@ -18,6 +18,8 @@ import type { Preset, LoadContext } from '@docusaurus/types';
 import docusaurusPresetClassic from '@docusaurus/preset-classic/lib';
 import type { Options } from '@docusaurus/preset-classic';
 
+import protoMessageRehypePlugin from '@protosaurus/rehype-plugin-codeblock';
+
 export type ProtosaurusPresetEntry = ['docusaurus-preset'];
 export type ProtosaurusPresetOptions = Options;
 
@@ -25,7 +27,17 @@ export default function protosaurusPreset(
   context: LoadContext,
   options: Options
 ): Preset {
-  const presetClassic = docusaurusPresetClassic(context, options);
+  const presetOpts = options;
+  const rehypePlugin = [protoMessageRehypePlugin, { siteDir: __dirname }];
+
+  if (typeof presetOpts?.docs === 'object') {
+    presetOpts.docs.rehypePlugins = presetOpts?.docs.rehypePlugins
+      ? [...presetOpts?.docs.rehypePlugins, rehypePlugin]
+      : ([rehypePlugin] as any);
+  }
+
+  const presetClassic = docusaurusPresetClassic(context, presetOpts);
+
   return {
     themes: [
       ...(presetClassic.themes || []),

--- a/packages/docusaurus-preset/src/index.ts
+++ b/packages/docusaurus-preset/src/index.ts
@@ -28,7 +28,7 @@ export default function protosaurusPreset(
   options: Options
 ): Preset {
   const presetOpts = options;
-  const rehypePlugin = [protoMessageRehypePlugin, { siteDir: __dirname }];
+  const rehypePlugin = [protoMessageRehypePlugin, { siteDir: context.siteDir }];
 
   if (typeof presetOpts?.docs === 'object') {
     presetOpts.docs.rehypePlugins = presetOpts?.docs.rehypePlugins

--- a/packages/rehype-plugin-codeblock/package.json
+++ b/packages/rehype-plugin-codeblock/package.json
@@ -2,6 +2,7 @@
   "name": "@protosaurus/rehype-plugin-codeblock",
   "version": "0.0.1",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/packages/rehype-plugin-codeblock/src/index.ts
+++ b/packages/rehype-plugin-codeblock/src/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { Plugin } from '@docusaurus/types';
 import { Comment, DocType, Element, Root, Text } from 'hast-format';
 import { getLinksFromALine, isLineAComment } from './comments';
 import { REPEATED_TEXT } from './constants';
@@ -22,11 +21,16 @@ import { getAllDictionaries } from './dictionary';
 import { getFieldInformation } from './fields';
 import { getHastElementType } from './hast';
 
-interface Options {
+export interface RehypePluginCodeblockOptions {
   siteDir: string;
 }
 
-const docusaurusPlugin: Plugin = (opts: Options) => {
+// TODO(imballinst): I tried to create a proper typing,
+// but it resulted in a mess. The `unified` ecosystem deps are ESM-only,
+// whereas @mdx-js/mdx is only CommonJS (and without typing)!
+// To save time and work on something more productive, let's set this to `any`... for now.
+// Revisit this when Docusaurus has moved to MDX v2.
+const docusaurusPlugin: any = (opts: RehypePluginCodeblockOptions) => {
   const { innerMessages, localMessages, wktMessages } =
     getAllDictionaries(opts);
 

--- a/packages/rehype-plugin-codeblock/tsconfig.json
+++ b/packages/rehype-plugin-codeblock/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "outDir": "lib/",
     "lib": ["esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "module": "CommonJS",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -49,8 +49,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
-          rehypePlugins: [[protoMessageRehypePlugin, { siteDir: __dirname }]]
+            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/'
         }
       })
     ]

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,6 @@
     "@protosaurus/cli": "0.0.2",
     "@protosaurus/docusaurus-plugin-mdx": "0.0.3",
     "@protosaurus/docusaurus-preset": "0.0.1",
-    "@protosaurus/rehype-plugin-codeblock": "0.0.1",
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",
     "prism-react-renderer": "^1.2.1",


### PR DESCRIPTION
This PR moves the rehype plugin to the Protosaurus preset that we have. I am using `any` here, regrettably, because we are using TypeScript without any bundlers + CommonJS only lib (MDX v1) + ESM only lib (Unified). To create a complete typing, I needed to deal with all 3 and it was not worth it.

The errors always revolve around:

1. SyntaxError: Cannot use import statement outside a module
2. require() of ES Module ... not supported
3. CustomError: ERR_UNSUPPORTED_DIR_IMPORT
4. Could not find a declaration file for module '@mdx-js/mdx'
5. TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for ...

I fixed one thing, the other error(s) showed up. It was just neverending, so I'll settle with this for now.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>