### PR TITLE
cli: change `docusaurus start/build` to `protosaurus start/build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ gen: $(BUF_V1_MODULE_DATA) $(yarn) ## Generate files from proto files
 	@$(MAKE) gen-wkt
 	@$(yarn) install --frozen-lockfile
 	@$(MAKE) gen-docusaurus-addons
-	@$(yarn) --cwd website protosaurus generate ../
 	@printf "$(ansi_format_bright)" $@ "ok"
 
 generated_dir := packages/wkt/generated/json

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ gen: $(BUF_V1_MODULE_DATA) $(yarn) ## Generate files from proto files
 	@$(MAKE) gen-wkt
 	@$(yarn) install --frozen-lockfile
 	@$(MAKE) gen-docusaurus-addons
+	@$(yarn) --cwd website protosaurus generate ../
 	@printf "$(ansi_format_bright)" $@ "ok"
 
 generated_dir := packages/wkt/generated/json

--- a/packages/cli/bin/protosaurus.js
+++ b/packages/cli/bin/protosaurus.js
@@ -19,7 +19,6 @@
 const generator = require('@protosaurus/generator');
 const mdx = require('@protosaurus/mdx');
 const path = require('path');
-const { spawn } = require('child_process');
 
 // The process is based on the `package.json` that calls this.
 const WORK_DIR = process.cwd();
@@ -42,6 +41,7 @@ const AVAILABLE_COMMANDS = ['start', 'build', 'clean', 'generate'];
   }
 
   const fs = await import('fs-extra');
+  const { execa } = await import('execa');
   const relativePathToBufGenYaml = relativePathArgs || '../';
   const pathToBufGenYaml = path.join(WORK_DIR, relativePathToBufGenYaml);
 
@@ -66,7 +66,7 @@ const AVAILABLE_COMMANDS = ['start', 'build', 'clean', 'generate'];
       // files first.
       await generate(pathToBufGenYaml);
       // After that, run docusaurus.
-      spawn('yarn', ['docusaurus', command], {
+      await execa('yarn', ['docusaurus', command], {
         cwd: WORK_DIR,
         stdio: 'inherit'
       });

--- a/packages/cli/bin/protosaurus.js
+++ b/packages/cli/bin/protosaurus.js
@@ -22,12 +22,12 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 // The process is based on the `package.json` that calls this.
-const DOCUSAURUS_DIR = process.cwd();
+const WORK_DIR = process.cwd();
 
 // TODO(imballinst): we should make this a proper CLI binary, with something like
 // meow or commander. commander still is a bit behind meow, unless this issue
 // https://github.com/sindresorhus/meow/issues/69 is fixed (regarding subcommands).
-const AVAILABLE_COMMANDS = ['start', 'build', 'clean'];
+const AVAILABLE_COMMANDS = ['start', 'build', 'clean', 'generate'];
 
 (async () => {
   const [_node, _protosaurus, command, relativePathArgs] = process.argv;
@@ -42,19 +42,20 @@ const AVAILABLE_COMMANDS = ['start', 'build', 'clean'];
   }
 
   const fs = await import('fs-extra');
+  const relativePathToBufGenYaml = relativePathArgs || '../';
+  const pathToBufGenYaml = path.join(WORK_DIR, relativePathToBufGenYaml);
 
   switch (command) {
     case 'clean': {
-      fs.rmdir(path.join(DOCUSAURUS_DIR, '.protosaurus'));
+      fs.rmdir(path.join(WORK_DIR, '.protosaurus'));
+      break;
+    }
+    case 'generate': {
+      await generate(pathToBufGenYaml);
+      break;
     }
     case 'start':
     case 'build': {
-      const relativePathToBufGenYaml = relativePathArgs || '../';
-      const pathToBufGenYaml = path.join(
-        DOCUSAURUS_DIR,
-        relativePathToBufGenYaml
-      );
-
       if (relativePathArgs === undefined) {
         console.warn(
           "No relative path argument to buf.gen.yaml directory given. It will default to '../'."
@@ -66,7 +67,7 @@ const AVAILABLE_COMMANDS = ['start', 'build', 'clean'];
       await generate(pathToBufGenYaml);
       // After that, run docusaurus.
       spawn('yarn', ['docusaurus', command], {
-        cwd: DOCUSAURUS_DIR,
+        cwd: WORK_DIR,
         stdio: 'inherit'
       });
     }
@@ -79,7 +80,7 @@ async function generate(pathToBufGenYaml) {
     workDir: pathToBufGenYaml
   });
 
-  const { pathToCache } = mdx.getPathsToCache(DOCUSAURUS_DIR);
+  const { pathToCache } = mdx.getPathsToCache(WORK_DIR);
   const isCacheInvalid = await mdx.isCacheInvalid({
     pathToCache,
     currentListOfFiles
@@ -94,14 +95,14 @@ async function generate(pathToBufGenYaml) {
     // Generate protoc JSON.
     await generator.generate({
       workDir: pathToBufGenYaml,
-      outPath: `${DOCUSAURUS_DIR}/.protosaurus/generated`
+      outPath: `${WORK_DIR}/.protosaurus/generated`
     });
     // Generate MDX and JSON dictionary from the generated JSON above.
-    await mdx.emitJsonAndMdx(DOCUSAURUS_DIR);
+    await mdx.emitJsonAndMdx(WORK_DIR);
   }
 
   await generator.generateCacheFile({
-    outPath: `${DOCUSAURUS_DIR}/.protosaurus/plugin-resources/.cache`,
+    outPath: `${WORK_DIR}/.protosaurus/plugin-resources/.cache`,
     newList: currentListOfFiles
   });
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@protosaurus/generator": "0.0.1",
     "@protosaurus/mdx": "0.0.3",
+    "execa": "6.1.0",
     "fs-extra": "10.0.0"
   },
   "peerDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,5 +12,8 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^2.0.0-beta.15"
+  },
+  "devDependencies": {
+    "@types/node": "17.0.21"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -3,16 +3,14 @@
   "version": "0.0.0",
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
-    "build": "docusaurus build",
+    "start": "protosaurus start",
+    "build": "protosaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "prestart": "protosaurus generate ../",
-    "prebuild": "protosaurus generate ../",
     "clean": "protosaurus clean"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,6 +1990,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.18.tgz#3b4fed5cfb58010e3a2be4b6e74615e4847f1074"
   integrity sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==
 
+"@types/node@17.0.21":
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+
 "@types/node@^17.0.5":
   version "17.0.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.19.tgz#726171367f404bfbe8512ba608a09ebad810c7e6"


### PR DESCRIPTION
This PR migrates the `docusaurus start` and `docusaurus build` to `protosaurus start` or `build`. Behind it, it will generate the required JSON/MDX files (if necessary).

`protosaurus build` or `protosaurus start` can receive 1 optional argument: the path to directory containing `buf.gen.yaml`. By default it's resolved to its parent directory.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>