### PR TITLE
plugin: implement collapsible code for protosaurus language using metastring

### DIFF
--- a/packages/docusaurus-theme/assets/custom.css
+++ b/packages/docusaurus-theme/assets/custom.css
@@ -40,7 +40,7 @@
 
 html[data-theme='dark'] {
   --ifm-pre-color: rgb(248, 248, 242);
-  --ifm-pre-background: rgb(40, 42, 54);
+  --ifm-pre-background-color: rgb(40, 42, 54);
 
   --precustom-comment-color: rgb(98, 114, 164);
   --precustom-type-color: rgb(189, 147, 249);
@@ -70,11 +70,15 @@ precustom {
   font: var(--ifm-code-font-size) / var(--ifm-pre-line-height)
     var(--ifm-font-family-monospace);
   white-space: pre;
-  background: var(--ifm-pre-background);
+  background: var(--ifm-pre-background-color);
   display: block;
   padding: var(--ifm-pre-padding);
   border-radius: var(--ifm-code-border-radius);
   /* TODO(imballinst): add overflow-x: auto here. */
+}
+
+precustom:not(:last-child) {
+  margin-bottom: var(--ifm-pre-padding);
 }
 
 precustom .comment {
@@ -83,6 +87,26 @@ precustom .comment {
 
 precustom .type {
   color: var(--precustom-type-color);
+}
+
+.precustom-code-title {
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  border-top-left-radius: var(--ifm-global-radius);
+  border-top-right-radius: var(--ifm-global-radius);
+  font-size: var(--ifm-code-font-size);
+  font-weight: 500;
+  padding: 0.75rem var(--ifm-pre-padding);
+  background: var(--ifm-pre-background-color);
+}
+
+.precustom-container .alert {
+  /* Reset the CSS style for these so that the code block style is consistent. */
+  --ifm-link-color: inherit;
+  --ifm-link-hover-color: inherit;
+  --ifm-link-decoration: inherit;
+  --ifm-pre-background: inherit;
+  --ifm-code-background: inherit;
+  --ifm-alert-background-color: transparent;
 }
 
 /* Button text to enable the image gallery. */

--- a/packages/rehype-plugin-codeblock/.mocharc.js
+++ b/packages/rehype-plugin-codeblock/.mocharc.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Protosaurus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// This is a JavaScript-based config file containing every Mocha option plus others.
+// If you need conditional logic, you might want to use this type of config,
+// e.g. set options via environment variables 'process.env'.
+// Otherwise, JSON or YAML is recommended.
+
+module.exports = {
+  diff: true,
+  // For some reasons we cannot use `global` field for `test` etc.
+  // We need to add them to `global.test` in the `setup-test.js` file.
+  file: ['./setup-test.js'],
+  spec: ['src/**/*.test.ts'],
+  require: 'ts-node/register'
+};

--- a/packages/rehype-plugin-codeblock/package.json
+++ b/packages/rehype-plugin-codeblock/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf lib && tsc --project tsconfig.build.json",
-    "mdx:test": "ts-node test-remark.ts"
+    "mdx:test": "ts-node test-remark.ts",
+    "test": "mocha"
   },
   "devDependencies": {
     "@types/hast-format": "2.3.0"

--- a/packages/rehype-plugin-codeblock/setup-test.js
+++ b/packages/rehype-plugin-codeblock/setup-test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Protosaurus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import mocha from 'mocha';
+
+global.test = mocha.test;

--- a/packages/rehype-plugin-codeblock/src/hast.ts
+++ b/packages/rehype-plugin-codeblock/src/hast.ts
@@ -15,6 +15,7 @@
  */
 
 import { Element } from 'hast-format';
+import { MetastringInfo, parseMetastring } from './metastring';
 import { LinkMatch, PartialSpecific, TextMatchField } from './types';
 
 export function getHastElementType(
@@ -70,6 +71,60 @@ export function getHastElementType(
       }
     ]
   };
+}
+
+export function wrapWithMetastringElements(
+  metastringInfo: MetastringInfo,
+  element: Element
+): Element[] {
+  const children: Element[] = [];
+
+  if (metastringInfo.isCollapsible) {
+    children.push({
+      type: 'element',
+      tagName: 'details',
+      children: [
+        {
+          type: 'element',
+          tagName: 'summary',
+          children: [
+            {
+              type: 'element',
+              tagName: 'span',
+              children: [
+                {
+                  type: 'text',
+                  value: metastringInfo.title
+                }
+              ]
+            }
+          ]
+        },
+        element
+      ]
+    });
+  } else if (metastringInfo.title) {
+    children.push(
+      {
+        type: 'element',
+        tagName: 'div',
+        properties: {
+          className: 'precustom-code-title'
+        },
+        children: [
+          {
+            type: 'text',
+            value: metastringInfo.title
+          }
+        ]
+      },
+      element
+    );
+  } else {
+    children.push(element);
+  }
+
+  return children;
 }
 
 export function getInfoSvgIcon(): Element {

--- a/packages/rehype-plugin-codeblock/src/hast.ts
+++ b/packages/rehype-plugin-codeblock/src/hast.ts
@@ -73,6 +73,7 @@ export function getHastElementType(
   };
 }
 
+// This function "transforms" an element if there is a metastring modifier.
 export function wrapWithMetastringElements(
   metastringInfo: MetastringInfo,
   element: Element
@@ -80,6 +81,11 @@ export function wrapWithMetastringElements(
   const children: Element[] = [];
 
   if (metastringInfo.isCollapsible) {
+    // The resulting JSX would be something like:
+    // <details>
+    //   <summary><span>{metastringInfo.title}</span></summary>
+    //   {element}
+    // </details>
     children.push({
       type: 'element',
       tagName: 'details',
@@ -104,6 +110,11 @@ export function wrapWithMetastringElements(
       ]
     });
   } else if (metastringInfo.title) {
+    // The resulting JSX would be something like:
+    // <>
+    //   <div>{metastringInfo.title}</div>
+    //   {element}
+    // </>
     children.push(
       {
         type: 'element',
@@ -121,6 +132,8 @@ export function wrapWithMetastringElements(
       element
     );
   } else {
+    // If there is no metastring modifier, then
+    // we keep it as it is.
     children.push(element);
   }
 

--- a/packages/rehype-plugin-codeblock/src/metastring.test.ts
+++ b/packages/rehype-plugin-codeblock/src/metastring.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import { parseMetastring } from './metastring';
+
+describe('metastring', () => {
+  test('none', () => {
+    expect(parseMetastring('', '')).to.eql({
+      title: '',
+      isCollapsible: false
+    });
+  });
+
+  test('title only', () => {
+    expect(parseMetastring('title="Hello world"', '')).to.eql({
+      title: 'Hello world',
+      isCollapsible: false
+    });
+  });
+
+  test('collapsible only: should throw an error', () => {
+    const codeContent = `
+message Booking {
+  int id = 1;
+}
+    `.trim();
+
+    expect(() => parseMetastring('collapsible', codeContent)).to.throw(
+      `When collapsible meta is set on code block, title should also be set. Error happens near: ${codeContent}`
+    );
+  });
+
+  test('title and collapsible', () => {
+    expect(parseMetastring('title="Hello world" collapsible', '')).to.eql({
+      title: 'Hello world',
+      isCollapsible: true
+    });
+
+    // Swap the positions.
+    expect(parseMetastring('collapsible title="Hello world"', '')).to.eql({
+      title: 'Hello world',
+      isCollapsible: true
+    });
+  });
+});

--- a/packages/rehype-plugin-codeblock/src/metastring.ts
+++ b/packages/rehype-plugin-codeblock/src/metastring.ts
@@ -1,0 +1,64 @@
+const TITLE_TOKEN = 'title="';
+const COLLAPSIBLE_TOKEN = 'collapsible';
+
+export interface MetastringInfo {
+  title: string;
+  isCollapsible: boolean;
+}
+
+// The reason this function is made is because,
+// Protosaurus language isn't identified in Prismjs, and the metadata
+// parsing is mostly done in Prismjs (e.g. code title).
+//
+// Available metas:
+// --> collapsible (for wrapping the snippet with <details> and <summary>)
+// --> title (for code title)
+// --> {num,num,num} (for highlighting)
+export function parseMetastring(
+  metastringParam: string,
+  codeContent: string
+): MetastringInfo {
+  let metastring = metastringParam;
+  // Parse title, if any.
+  const titleStartIdx = metastring.indexOf(TITLE_TOKEN);
+  const titleEndIdx = metastring.indexOf(
+    '"',
+    titleStartIdx + TITLE_TOKEN.length
+  );
+  let title = '';
+
+  if (titleStartIdx > -1 && titleEndIdx > -1) {
+    const titleIdxPlusToken = titleStartIdx + TITLE_TOKEN.length;
+
+    title = metastring.slice(titleIdxPlusToken, titleEndIdx);
+    metastring = metastring
+      .slice(0, titleIdxPlusToken)
+      .concat(metastring.slice(titleEndIdx + 1));
+  }
+
+  // Parse collapsible.
+  let isCollapsible = false;
+
+  const collapsibleIdx = metastring.indexOf(COLLAPSIBLE_TOKEN);
+  if (collapsibleIdx > -1) {
+    isCollapsible = true;
+    metastring = metastring
+      .slice(0, collapsibleIdx)
+      .concat(metastring.slice(collapsibleIdx + COLLAPSIBLE_TOKEN.length));
+  }
+
+  // If it is collapsible but does not have title, then throw an error.
+  // This is because, we need a title for the <summary> tag.
+  if (isCollapsible && title === '') {
+    throw new Error(
+      `When collapsible meta is set on code block, title should also be set. Error happens near: ${codeContent}`
+    );
+  }
+
+  // Parse line highlights.
+  // TODO(imballinst): not a priority now since it's more recommended to use inline ones.
+  return {
+    title,
+    isCollapsible
+  };
+}

--- a/packages/rehype-plugin-codeblock/test-remark.ts
+++ b/packages/rehype-plugin-codeblock/test-remark.ts
@@ -47,5 +47,5 @@ async function main() {
     ]
   });
   // Hide this as needed.
-  // console.log(result);
+  console.log(result);
 }

--- a/packages/rehype-plugin-codeblock/tsconfig.json
+++ b/packages/rehype-plugin-codeblock/tsconfig.json
@@ -14,6 +14,5 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src", "./test-remark.ts"],
-  "exclude": ["src/*.test.ts"]
+  "include": ["src", "./test-remark.ts"]
 }

--- a/website/docs/test.mdx
+++ b/website/docs/test.mdx
@@ -18,38 +18,37 @@ import ProtosaurusAnnotation from "@theme/ProtosaurusAnnotation";
 
 <ProtosaurusAnnotation />
 
-## Messages
+## Hello world
 
-<Definition>
-
-<DefinitionHeader name="message">
-
-### Booking
-
-</DefinitionHeader>
-
-Represents the booking of a vehicle.
-
-Vehicles are some cool shit. But drive carefully.
-
-```protosaurus--booking.v1.Booking
+```protobuf title="Hello world" collapsible
 message Booking {
   // ID of booked vehicle.
   int32 vehicle_id = 1;
-
-  // Customer that booked the vehicle. [^1]
-  // highlight-next-line
-  int32 customer_id = 2; // [^2]
+  // Customer that booked the vehicle.
+  int32 customer_id = 2;
+  // Status of the booking.
+  BookingStatus status = 3;
 }
 ```
 
-</Definition>
+```protosaurus title="Hello world" collapsible
+message Booking {
+  // ID of booked vehicle.
+  int32 vehicle_id = 1;
+  // Customer that booked the vehicle.
+  int32 customer_id = 2;
+  // Status of the booking.
+  BookingStatus status = 3;
+}
+```
 
-Pretty sure we can still annotation outside of the codeblock[^3], right?
-
-Let's see annotations between [^4] texts.
-
-[^1]: this is a sample annotation. I can also put `code` hree!
-[^2]: this is another sample annotation.
-[^3]: it works!
-[^4]: hello world
+```protosaurus title="Hello world"
+message Booking {
+  // ID of booked vehicle.
+  int32 vehicle_id = 1;
+  // Customer that booked the vehicle.
+  int32 customer_id = 2;
+  // Status of the booking.
+  BookingStatus status = 3;
+}
+```


### PR DESCRIPTION
This PR implements the collapsible code for protosaurus language, utilizing the metastring. Key features:

1. Code title (with `title="..."`)
2. Collapsible code with (`collapsible`)

Link to page: https://imballinst.github.io/protosaurus/pr-33/docs/test

![image](https://user-images.githubusercontent.com/7077157/156397289-a9deeb31-b6fc-42e4-9757-4ae9cb8ff5bd.png)

![image](https://user-images.githubusercontent.com/7077157/156397299-a60f4e30-7174-4d6d-aad2-dcc112cac4c8.png)

![image](https://user-images.githubusercontent.com/7077157/156397309-ac8703c1-f8f9-4a7e-975d-f6c3ca36bd8a.png)

## How it works

1. We parse the metastring
2. If there is only title, then we add the title element before the code
4. If there is only collapsible, throw an error (included in test)
5. If there are both, then the title is used as the collapsible title

## Next steps

1. Apply it for non-protosaurus language as well (currently we need to use `<details>` tag
2. Implement line highlighting for protosaurus language using metastring
4. Do all the minor `TODO`s.
5. Perhaps it's a good time to refactor `packages/rehype-plugin-codeblock/src/index.ts`.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>