### PR TITLE
plugin: implement collapsible code block for other languages

### DIFF
--- a/packages/docusaurus-theme/assets/custom.css
+++ b/packages/docusaurus-theme/assets/custom.css
@@ -99,7 +99,7 @@ precustom .type {
   background: var(--ifm-pre-background-color);
 }
 
-.precustom-container .alert {
+.protosaurus-code-container .alert {
   /* Reset the CSS style for these so that the code block style is consistent. */
   --ifm-link-color: inherit;
   --ifm-link-hover-color: inherit;
@@ -107,6 +107,7 @@ precustom .type {
   --ifm-pre-background: inherit;
   --ifm-code-background: inherit;
   --ifm-alert-background-color: transparent;
+  --ifm-leading: 0;
 }
 
 /* Button text to enable the image gallery. */

--- a/packages/docusaurus-theme/assets/custom.css
+++ b/packages/docusaurus-theme/assets/custom.css
@@ -107,6 +107,7 @@ precustom .type {
   --ifm-pre-background: inherit;
   --ifm-code-background: inherit;
   --ifm-alert-background-color: transparent;
+  /* Removes the margin in if a code block exists inside a collapsible. */
   --ifm-leading: 0;
 }
 

--- a/packages/rehype-plugin-codeblock/src/index.ts
+++ b/packages/rehype-plugin-codeblock/src/index.ts
@@ -24,7 +24,7 @@ import {
   getInfoSvgIcon,
   wrapWithMetastringElements
 } from './hast';
-import { parseMetastring } from './metastring';
+import { parseMetastring, stripTitleFromElementProperties } from './metastring';
 
 export interface RehypePluginCodeblockOptions {
   siteDir: string;
@@ -164,14 +164,24 @@ const docusaurusPlugin: any = (opts: RehypePluginCodeblockOptions) => {
           c.startsWith('language-protosaurus')
         );
 
-        if (!matchingLanguage) {
-          continue;
-        }
-
         const metastringInfo = parseMetastring(
           code?.properties?.metastring || '',
           codeChild.value
         );
+
+        if (!matchingLanguage) {
+          // Languages other than protosaurus.
+          pre.children = wrapWithMetastringElements(metastringInfo, { ...pre });
+          pre.properties = {
+            className: 'protosaurus-code-container'
+          };
+          pre.tagName = 'div';
+          // Strip the title from the code element, if metastringInfo.collapsible is true.
+          if (metastringInfo.isCollapsible) {
+            code.properties = stripTitleFromElementProperties(code.properties);
+          }
+          continue;
+        }
 
         // For example: the format is `language-protosaurus--booking.v1.Booking`.
         // This has the purpose to "detect" submessages.
@@ -550,7 +560,7 @@ const docusaurusPlugin: any = (opts: RehypePluginCodeblockOptions) => {
         // Rewrite the tag name from `pre` to `precustom` so we could
         // make a difference between normal `pre` and our `pre`.
         pre.properties = {
-          className: 'precustom-container'
+          className: 'protosaurus-code-container'
         };
         pre.tagName = 'div';
       }

--- a/packages/rehype-plugin-codeblock/src/index.ts
+++ b/packages/rehype-plugin-codeblock/src/index.ts
@@ -176,10 +176,9 @@ const docusaurusPlugin: any = (opts: RehypePluginCodeblockOptions) => {
             className: 'protosaurus-code-container'
           };
           pre.tagName = 'div';
-          // Strip the title from the code element, if metastringInfo.collapsible is true.
-          if (metastringInfo.isCollapsible) {
-            code.properties = stripTitleFromElementProperties(code.properties);
-          }
+          // Strip the title from the metastring, so that Prism.js will not
+          // duplicate the code title.
+          code.properties = stripTitleFromElementProperties(code.properties);
           continue;
         }
 

--- a/packages/rehype-plugin-codeblock/src/metastring.test.ts
+++ b/packages/rehype-plugin-codeblock/src/metastring.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { parseMetastring } from './metastring';
+import { parseMetastring, stripTitleFromElementProperties } from './metastring';
 
-describe('metastring', () => {
+describe('parseMetastring', () => {
   test('none', () => {
     expect(parseMetastring('', '')).to.eql({
       title: '',
@@ -39,5 +39,43 @@ message Booking {
       title: 'Hello world',
       isCollapsible: true
     });
+  });
+});
+
+describe('stripTitleFromElementProperties', () => {
+  test('none', () => {
+    expect(stripTitleFromElementProperties({})).to.eql({});
+    expect(stripTitleFromElementProperties(undefined)).to.eql(undefined);
+  });
+
+  test('title only', () => {
+    expect(
+      stripTitleFromElementProperties({ title: '"Hello', 'World"': true })
+    ).to.eql({});
+  });
+
+  test('collapsible only', () => {
+    expect(stripTitleFromElementProperties({ collapsible: true })).to.eql({
+      collapsible: true
+    });
+  });
+
+  test('title and collapsible', () => {
+    expect(
+      stripTitleFromElementProperties({
+        title: '"Hello',
+        'World"': true,
+        collapsible: true
+      })
+    ).to.eql({ collapsible: true });
+
+    // Swap the positions.
+    expect(
+      stripTitleFromElementProperties({
+        collapsible: true,
+        title: '"Hello',
+        'World"': true
+      })
+    ).to.eql({ collapsible: true });
   });
 });

--- a/packages/rehype-plugin-codeblock/src/metastring.ts
+++ b/packages/rehype-plugin-codeblock/src/metastring.ts
@@ -1,3 +1,5 @@
+import { Element } from 'hast-format';
+
 const TITLE_TOKEN = 'title="';
 const COLLAPSIBLE_TOKEN = 'collapsible';
 
@@ -61,4 +63,54 @@ export function parseMetastring(
     title,
     isCollapsible
   };
+}
+
+export function stripTitleFromElementProperties(
+  properties: Element['properties']
+) {
+  if (properties === undefined) {
+    // Exit early.
+    return undefined;
+  }
+
+  const keys = Object.keys(properties);
+  const titleIdx = keys.indexOf('title');
+  if (titleIdx === -1) {
+    // Exit early when no title key is found.
+    return properties;
+  }
+
+  // Here, we need to do 2 things.
+  // The first one is, we need to delete the title-related keys.
+  // It is contained in `metastring`, `title`, and one key after `title`.
+  // For more information, please see the properties example in the test file.
+  const newProperties = { ...properties };
+  const titleEndIdx = titleIdx + 1;
+  // Delete the title-related keys.
+  delete newProperties[keys[titleIdx]];
+  delete newProperties[keys[titleEndIdx]];
+
+  // Also trim it from the metastring.
+  const metastring = newProperties.metastring || '';
+  const metastringTitleIdx = metastring.indexOf(TITLE_TOKEN);
+  // Only try to trim it when we find the TITLE_TOKEN substring, which most likely
+  // exists, if things are working normally in the remark/rehype transformer.
+  if (metastringTitleIdx > -1) {
+    const metaStringTitleEndIdx = metastring.indexOf(
+      '"',
+      metastringTitleIdx + TITLE_TOKEN.length
+    );
+
+    // Do a preventive slicing. This covers 3 cases:
+    //
+    // 1. title at the start of the string
+    // 2. title in the middle of the string
+    // 3. title at the end of the string
+    newProperties.metastring = metastring
+      .slice(0, metastringTitleIdx)
+      .concat(metastring.slice(metaStringTitleEndIdx + 1))
+      .trim();
+  }
+
+  return newProperties;
 }

--- a/website/docs/test.mdx
+++ b/website/docs/test.mdx
@@ -20,7 +20,7 @@ import ProtosaurusAnnotation from "@theme/ProtosaurusAnnotation";
 
 ## Hello world
 
-```protobuf title="Hello world" collapsible
+```protobuf title="Hello world" collapsible {1,3-5}
 message Booking {
   // ID of booked vehicle.
   int32 vehicle_id = 1;

--- a/website/docs/test.mdx
+++ b/website/docs/test.mdx
@@ -20,6 +20,17 @@ import ProtosaurusAnnotation from "@theme/ProtosaurusAnnotation";
 
 ## Hello world
 
+```protobuf title="Hello world" {1,3-5}
+message Booking {
+  // ID of booked vehicle.
+  int32 vehicle_id = 1;
+  // Customer that booked the vehicle.
+  int32 customer_id = 2;
+  // Status of the booking.
+  BookingStatus status = 3;
+}
+```
+
 ```protobuf title="Hello world" collapsible {1,3-5}
 message Booking {
   // ID of booked vehicle.


### PR DESCRIPTION
This PR implements collapsible code block for other languages. Due to the nature of the metastring for normal code block, the plugin now "trims" the properties that are related to code title. This is done so that Prism.js will not duplicate the code title. The steps are as the following:

1. Parse the metastring
2. Wrap the code element using our `wrapWithMetastringElements` function
3. Trim the strings and keys that are related to the code title

## Screenshots

![image](https://user-images.githubusercontent.com/7077157/156712078-7d432fa9-e5f0-4225-88cd-f8f3f38abaae.png)

![image](https://user-images.githubusercontent.com/7077157/156712087-6c02d14c-b7b4-4752-8dad-3b5c585aafa4.png)

Signed-off-by: Try Ajitiono <ballinst@gmail.com>