### PR TITLE
ci: enable checking license header existence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,8 @@ jobs:
           key: protosaurus-${{ runner.os }}-buf-${{ hashFiles('testdata/buf.lock') }}
           restore-keys: protosaurus-${{ runner.os }}-buf-
 
+      # First and foremost, check if there are files without license.
+      - run: make license-check
       - run: make gen
 
       # Check for code formatting.

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,13 @@ prettier-check: $(yarn)
 	@$(yarn) prettier packages website -c
 
 license_files := website packages testdata .github Makefile *.mk buf.*.yaml
+license_ignore := packages/**/node_modules/*.{ts,js}
+
 license: $(addlicense) ## Add license to files
-	@$(addlicense) $(license_ignore) -c "Protosaurus Authors"  $(license_files) 1>/dev/null 2>&1
+	@$(addlicense) -ignore $(license_ignore) -c "Protosaurus Authors"  $(license_files) 1>/dev/null 2>&1
+
+license-check: $(addlicense) ## Check license existence
+	@$(addlicense) -check -ignore $(license_ignore) $(license_files)
 
 test:
 	@WORK_DIR=$(root_dir) $(yarn) --cwd $(mdx_generator) test


### PR DESCRIPTION
This PR enables the license header existence check using this as the guideline: https://github.com/google/addlicense#usage. Example demo:

```
➜  protosaurus git:(ci-check-license) ✗ tree packages/cli -L 2
packages/cli
├── bin
│   └── protosaurus.js
├── node_modules
│   ├── test.js
│   └── @types
├── package.json
├── README.md
└── test.js

3 directories, 5 files
➜  protosaurus git:(ci-check-license) ✗ make license-check         
2022/03/08 10:05:34 skipping: packages/cli/node_modules/test.js
packages/cli/test.js
make: *** [Makefile:148: license-check] Error 1
```

Signed-off-by: Try Ajitiono <ballinst@gmail.com>